### PR TITLE
Refactor: 사용하지 않는 API 제거

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -1,19 +1,17 @@
 package org.cotato.csquiz.api.member.controller;
 
-import org.cotato.csquiz.domain.auth.service.MemberService;
-import org.cotato.csquiz.common.config.jwt.JwtTokenProvider;
-import org.cotato.csquiz.api.admin.dto.MemberInfoResponse;
-import org.cotato.csquiz.api.member.dto.CheckPasswordRequest;
-import org.cotato.csquiz.api.member.dto.MemberMyPageInfoResponse;
-import org.cotato.csquiz.api.member.dto.UpdatePasswordRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.api.admin.dto.MemberInfoResponse;
+import org.cotato.csquiz.api.member.dto.MemberMyPageInfoResponse;
+import org.cotato.csquiz.api.member.dto.UpdatePasswordRequest;
+import org.cotato.csquiz.common.config.jwt.JwtTokenProvider;
+import org.cotato.csquiz.domain.auth.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,14 +32,6 @@ public class MemberController {
         String accessToken = jwtTokenProvider.getBearer(authorizationHeader);
         Long memberId = jwtTokenProvider.getMemberId(accessToken);
         return ResponseEntity.ok().body(memberService.findMemberInfo(memberId));
-    }
-
-    @PostMapping("/check/password")
-    public ResponseEntity<Void> checkPassword(@RequestHeader("Authorization") String authorizationHeader,
-                                              @RequestBody @Valid CheckPasswordRequest request) {
-        String accessToken = jwtTokenProvider.getBearer(authorizationHeader);
-        memberService.checkCorrectPassword(accessToken, request.password());
-        return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/update/password")

--- a/src/main/java/org/cotato/csquiz/api/quiz/controller/QuizController.java
+++ b/src/main/java/org/cotato/csquiz/api/quiz/controller/QuizController.java
@@ -64,14 +64,6 @@ public class QuizController {
         return ResponseEntity.ok(quizService.findQuizForAdminCsQuiz(quizId));
     }
 
-    @PostMapping("/cs-admin/answer/add")
-    public ResponseEntity<Void> addAnswer(@RequestBody @Valid AddAdditionalAnswerRequest request) {
-        quizService.addAdditionalAnswer(request);
-        recordService.addAdditionalAnswerToRedis(request);
-
-        return ResponseEntity.noContent().build();
-    }
-
     @GetMapping("/cs-admin/results")
     public ResponseEntity<List<QuizResultInfo>> quizResults(@RequestParam("educationId") Long educationId) {
         return ResponseEntity.ok(quizService.createQuizResults(educationId));

--- a/src/main/java/org/cotato/csquiz/api/quiz/controller/QuizController.java
+++ b/src/main/java/org/cotato/csquiz/api/quiz/controller/QuizController.java
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class QuizController {
 
     private final QuizService quizService;
-    private final RecordService recordService;
 
     @PostMapping(value = "/adds", consumes = "multipart/form-data")
     public ResponseEntity<Void> addAllQuizzes(@ModelAttribute CreateQuizzesRequest request,
@@ -65,9 +64,8 @@ public class QuizController {
     }
 
     @PostMapping("/cs-admin/answer/add")
-    public ResponseEntity<Void> addAnswer(@RequestBody @Valid AddAdditionalAnswerRequest request) {
+    public ResponseEntity<Void> addAdditionalAnswer(@RequestBody @Valid AddAdditionalAnswerRequest request) {
         quizService.addAdditionalAnswer(request);
-        recordService.addAdditionalAnswerToRedis(request);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/cotato/csquiz/api/quiz/controller/QuizController.java
+++ b/src/main/java/org/cotato/csquiz/api/quiz/controller/QuizController.java
@@ -64,6 +64,14 @@ public class QuizController {
         return ResponseEntity.ok(quizService.findQuizForAdminCsQuiz(quizId));
     }
 
+    @PostMapping("/cs-admin/answer/add")
+    public ResponseEntity<Void> addAnswer(@RequestBody @Valid AddAdditionalAnswerRequest request) {
+        quizService.addAdditionalAnswer(request);
+        recordService.addAdditionalAnswerToRedis(request);
+
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping("/cs-admin/results")
     public ResponseEntity<List<QuizResultInfo>> quizResults(@RequestParam("educationId") Long educationId) {
         return ResponseEntity.ok(quizService.createQuizResults(educationId));

--- a/src/main/java/org/cotato/csquiz/api/socket/controller/SocketController.java
+++ b/src/main/java/org/cotato/csquiz/api/socket/controller/SocketController.java
@@ -30,7 +30,7 @@ public class SocketController {
     @PatchMapping("/start/csquiz")
     public ResponseEntity<Void> openCSQuiz(@RequestBody @Valid QuizOpenRequest request) {
         socketService.openCSQuiz(request);
-        recordService.saveAnswers(request);
+        recordService.saveAnswersToCache(request);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -46,8 +46,10 @@ public enum ErrorCode {
     MEMBER_CANT_ACCESS(HttpStatus.BAD_REQUEST, "E-403", "해당 멤버의 ROLE로 접근할 수 없습니다"),
 
     INVALID_ANSWER(HttpStatus.BAD_REQUEST, "Q-101", "객관식 문제는 숫자 형식의 값만 정답으로 추가할 수 있습니다."),
+    CONTENT_IS_NOT_ANSWER(HttpStatus.BAD_REQUEST, "Q-201", "추가되지 않은 정답을 추가할 수 없습니다."),
     QUIZ_NUMBER_DUPLICATED(HttpStatus.CONFLICT, "Q-301", "퀴즈 번호는 중복될 수 없습니다."),
     CHOICE_NUMBER_DUPLICATED(HttpStatus.CONFLICT, "Q-302", "선지 번호는 중복될 수 없습니다"),
+    CONTENT_IS_ALREADY_ANSWER(HttpStatus.BAD_REQUEST, "Q-303", "이미 정답인 답을 추가했습니다"),
     QUIZ_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "Q-401", "해당 퀴즈는 아직 접근할 수 없습니다."),
     QUIZ_TYPE_NOT_MATCH(HttpStatus.BAD_REQUEST, "Q-402", "주관식 정답만 추가 가능합니다."),
 

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -31,7 +31,6 @@ public enum ErrorCode {
 
     //회원 관련
     ROLE_IS_NOT_MATCH(HttpStatus.BAD_REQUEST, "M-101", "해당 ROLE은 변경할 수 없습니다."),
-    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "M-102", "비밀번호가 일치하지 않습니다."),
     ROLE_IS_NOT_OLD_MEMBER(HttpStatus.BAD_REQUEST, "M-103", "해당 회원의 ROLE은 OLD_MEMBER가 아닙니다."),
     SAME_PASSWORD(HttpStatus.CONFLICT, "M-301", "이전과 같은 비밀번호로 변경할 수 없습니다."),
 

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -46,10 +46,8 @@ public enum ErrorCode {
     MEMBER_CANT_ACCESS(HttpStatus.BAD_REQUEST, "E-403", "해당 멤버의 ROLE로 접근할 수 없습니다"),
 
     INVALID_ANSWER(HttpStatus.BAD_REQUEST, "Q-101", "객관식 문제는 숫자 형식의 값만 정답으로 추가할 수 있습니다."),
-    CONTENT_IS_NOT_ANSWER(HttpStatus.BAD_REQUEST, "Q-201", "추가되지 않은 정답을 추가할 수 없습니다."),
     QUIZ_NUMBER_DUPLICATED(HttpStatus.CONFLICT, "Q-301", "퀴즈 번호는 중복될 수 없습니다."),
     CHOICE_NUMBER_DUPLICATED(HttpStatus.CONFLICT, "Q-302", "선지 번호는 중복될 수 없습니다"),
-    CONTENT_IS_ALREADY_ANSWER(HttpStatus.BAD_REQUEST, "Q-303", "이미 정답인 답을 추가했습니다"),
     QUIZ_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "Q-401", "해당 퀴즈는 아직 접근할 수 없습니다."),
     QUIZ_TYPE_NOT_MATCH(HttpStatus.BAD_REQUEST, "Q-402", "주관식 정답만 추가 가능합니다."),
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -43,15 +43,6 @@ public class MemberService {
         return originPhoneNumber.substring(numberLength - 4);
     }
 
-    public void checkCorrectPassword(String accessToken, String password) {
-        Long memberId = jwtTokenProvider.getMemberId(accessToken);
-        Member findMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
-        if (!bCryptPasswordEncoder.matches(password, findMember.getPassword())) {
-            throw new AppException(ErrorCode.PASSWORD_NOT_MATCH);
-        }
-    }
-
     @Transactional
     public void updatePassword(String accessToken, String password) {
         Long memberId = jwtTokenProvider.getMemberId(accessToken);

--- a/src/main/java/org/cotato/csquiz/domain/education/cache/QuizAnswerRedisRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/cache/QuizAnswerRedisRepository.java
@@ -27,14 +27,14 @@ public class QuizAnswerRedisRepository {
 
     private static final String KEY_PREFIX = "$quiz";
     private static final Integer QUIZ_ANSWER_EXPIRATION_TIME = 60 * 24;
-    private final QuizRepository quizRepository;
     private final ShortAnswerRepository shortAnswerRepository;
     private final ChoiceRepository choiceRepository;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public void saveAllQuizAnswers(Long educationId) {
-        List<Quiz> allQuizzes = quizRepository.findAllByEducationId(educationId);
-        allQuizzes.forEach(this::saveQuizAnswer);
+    public void saveAllQuizAnswers(List<Quiz> quizzes) {
+        for (Quiz quiz : quizzes) {
+            saveQuizAnswer(quiz);
+        }
     }
 
     public void saveAdditionalQuizAnswer(Quiz quiz, String answer) {
@@ -76,7 +76,7 @@ public class QuizAnswerRedisRepository {
         }
     }
 
-    private void saveShortAnswer(Quiz quiz) {
+    private void saveShortAnswer(final Quiz quiz) {
         List<ShortAnswer> shortAnswers = shortAnswerRepository.findAllByShortQuiz((ShortQuiz) quiz);
         List<String> answers = shortAnswers.stream()
                 .map(ShortAnswer::getContent)
@@ -90,7 +90,7 @@ public class QuizAnswerRedisRepository {
         redisTemplate.expire(quizKey, QUIZ_ANSWER_EXPIRATION_TIME, TimeUnit.MINUTES);
     }
 
-    private void saveChoices(Quiz quiz) {
+    private void saveChoices(final Quiz quiz) {
         List<Choice> choices = choiceRepository.findAllByMultipleQuiz((MultipleQuiz) quiz);
         List<Integer> answerNumbers = choices.stream().filter(choice -> choice.getIsCorrect() == ChoiceCorrect.ANSWER)
                 .map(Choice::getChoiceNumber).toList();

--- a/src/main/java/org/cotato/csquiz/domain/education/cache/QuizAnswerRedisRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/cache/QuizAnswerRedisRepository.java
@@ -37,36 +37,6 @@ public class QuizAnswerRedisRepository {
         allQuizzes.forEach(this::saveQuizAnswer);
     }
 
-    public void saveAdditionalQuizAnswer(Quiz quiz, String answer) {
-        if (quiz instanceof ShortQuiz) {
-            ShortAnswer shortAnswer = shortAnswerRepository.findByShortQuizAndContent((ShortQuiz) quiz, answer)
-                    .orElseThrow(() -> new AppException(ErrorCode.CONTENT_IS_NOT_ANSWER));
-
-            saveAdditionalShortQuizAnswer(quiz, shortAnswer.getContent());
-        }
-
-        if (quiz instanceof MultipleQuiz) {
-            Choice choice = choiceRepository.findByMultipleQuizAndChoiceNumber((MultipleQuiz) quiz,
-                            Integer.parseInt(answer))
-                    .orElseThrow(() -> new AppException(ErrorCode.CONTENT_IS_NOT_ANSWER));
-            saveAdditionalMultipleQuizAnswer(quiz, choice.getChoiceNumber());
-        }
-    }
-
-    private void saveAdditionalMultipleQuizAnswer(Quiz quiz, Integer answerNumber) {
-        String quizKey = KEY_PREFIX + quiz.getId();
-
-        redisTemplate.opsForList().rightPush(quizKey, answerNumber);
-        redisTemplate.expire(quizKey, QUIZ_ANSWER_EXPIRATION_TIME, TimeUnit.MINUTES);
-    }
-
-    private void saveAdditionalShortQuizAnswer(Quiz quiz, String answer) {
-        String quizKey = KEY_PREFIX + quiz.getId();
-
-        redisTemplate.opsForList().rightPush(quizKey, answer);
-        redisTemplate.expire(quizKey, QUIZ_ANSWER_EXPIRATION_TIME, TimeUnit.MINUTES);
-    }
-
     public void saveQuizAnswer(Quiz quiz) {
         if (quiz instanceof ShortQuiz) {
             saveShortAnswer(quiz);

--- a/src/main/java/org/cotato/csquiz/domain/education/cache/QuizAnswerRedisRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/cache/QuizAnswerRedisRepository.java
@@ -37,6 +37,36 @@ public class QuizAnswerRedisRepository {
         allQuizzes.forEach(this::saveQuizAnswer);
     }
 
+    public void saveAdditionalQuizAnswer(Quiz quiz, String answer) {
+        if (quiz instanceof ShortQuiz) {
+            ShortAnswer shortAnswer = shortAnswerRepository.findByShortQuizAndContent((ShortQuiz) quiz, answer)
+                    .orElseThrow(() -> new AppException(ErrorCode.CONTENT_IS_NOT_ANSWER));
+
+            saveAdditionalShortQuizAnswer(quiz, shortAnswer.getContent());
+        }
+
+        if (quiz instanceof MultipleQuiz) {
+            Choice choice = choiceRepository.findByMultipleQuizAndChoiceNumber((MultipleQuiz) quiz,
+                            Integer.parseInt(answer))
+                    .orElseThrow(() -> new AppException(ErrorCode.CONTENT_IS_NOT_ANSWER));
+            saveAdditionalMultipleQuizAnswer(quiz, choice.getChoiceNumber());
+        }
+    }
+
+    private void saveAdditionalMultipleQuizAnswer(Quiz quiz, Integer answerNumber) {
+        String quizKey = KEY_PREFIX + quiz.getId();
+
+        redisTemplate.opsForList().rightPush(quizKey, answerNumber);
+        redisTemplate.expire(quizKey, QUIZ_ANSWER_EXPIRATION_TIME, TimeUnit.MINUTES);
+    }
+
+    private void saveAdditionalShortQuizAnswer(Quiz quiz, String answer) {
+        String quizKey = KEY_PREFIX + quiz.getId();
+
+        redisTemplate.opsForList().rightPush(quizKey, answer);
+        redisTemplate.expire(quizKey, QUIZ_ANSWER_EXPIRATION_TIME, TimeUnit.MINUTES);
+    }
+
     public void saveQuizAnswer(Quiz quiz) {
         if (quiz instanceof ShortQuiz) {
             saveShortAnswer(quiz);

--- a/src/main/java/org/cotato/csquiz/domain/education/cache/ScorerExistRedisRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/cache/ScorerExistRedisRepository.java
@@ -15,22 +15,18 @@ public class ScorerExistRedisRepository {
     private static final String KEY_PREFIX = "$Scorer for ";
     private static final Long NONE_VALUE = Long.MAX_VALUE;
     private static final Integer SCORER_EXPIRATION = 60 * 24;
-    private final QuizRepository quizRepository;
     private final RedisTemplate<String, Long> redisTemplate;
 
-    public void saveAllScorerNone(Long educationId) {
-        List<Quiz> quizzes = quizRepository.findAllByEducationId(educationId);
-        quizzes.forEach(this::saveScorerNone);
-    }
-
-    private void saveScorerNone(Quiz quiz) {
-        String quizKey = KEY_PREFIX + quiz.getId();
-        redisTemplate.opsForValue().set(
-                quizKey,
-                NONE_VALUE,
-                SCORER_EXPIRATION,
-                TimeUnit.MINUTES
-        );
+    public void saveAllScorerNone(List<Quiz> quizzes) {
+        for (Quiz quiz : quizzes) {
+            String quizKey = KEY_PREFIX + quiz.getId();
+            redisTemplate.opsForValue().set(
+                    quizKey,
+                    NONE_VALUE,
+                    SCORER_EXPIRATION,
+                    TimeUnit.MINUTES
+            );
+        }
     }
 
     public void saveScorer(Quiz quiz, Long ticketNumber) {

--- a/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
@@ -134,8 +134,7 @@ public class QuizService {
 
         List<ShortAnswer> shortAnswers = request.getShortAnswers().stream()
                 .map(CreateShortAnswerRequest::getAnswer)
-                .map(String::toLowerCase)
-                .map(String::trim)
+                .map(AnswerUtil::processAnswer)
                 .map(answer -> ShortAnswer.of(answer, createdShortQuiz))
                 .toList();
         shortAnswerRepository.saveAll(shortAnswers);

--- a/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
@@ -286,45 +286,6 @@ public class QuizService {
                 .toList();
     }
 
-    @Transactional
-    public void addAdditionalAnswer(AddAdditionalAnswerRequest request) {
-        Quiz quiz = findQuizById(request.quizId());
-        if (quiz instanceof ShortQuiz) {
-            addShortAnswer((ShortQuiz) quiz, request.answer());
-        }
-        if (quiz instanceof MultipleQuiz) {
-            addCorrectChoice((MultipleQuiz) quiz, request.answer());
-        }
-    }
-
-    private void addShortAnswer(ShortQuiz shortQuiz, String answer) {
-        checkAnswerAlreadyExist(shortQuiz, answer);
-
-        String cleanedAnswer = answer.toLowerCase()
-                .trim();
-        ShortAnswer shortAnswer = ShortAnswer.of(cleanedAnswer, shortQuiz);
-
-        shortAnswerRepository.save(shortAnswer);
-    }
-
-    private void checkAnswerAlreadyExist(ShortQuiz shortQuiz, String answer) {
-        shortAnswerRepository.findByShortQuizAndContent(shortQuiz, answer)
-                .ifPresent(existingAnswer -> {
-                    throw new AppException(ErrorCode.CONTENT_IS_ALREADY_ANSWER);
-                });
-    }
-
-    private void addCorrectChoice(MultipleQuiz multipleQuiz, String answer) {
-        try {
-            int choiceNumber = Integer.parseInt(answer);
-            Choice choice = choiceRepository.findByMultipleQuizAndChoiceNumber(multipleQuiz, choiceNumber)
-                    .orElseThrow(() -> new EntityNotFoundException("해당 번호의 선지를 찾을 수 없습니다."));
-            choice.updateCorrect(ChoiceCorrect.ANSWER);
-        } catch (NumberFormatException e) {
-            throw new AppException(ErrorCode.INVALID_ANSWER);
-        }
-    }
-
     private Quiz findQuizById(Long quizId) {
         return quizRepository.findById(quizId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 퀴즈를 찾을 수 없습니다."));

--- a/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
@@ -46,6 +46,7 @@ import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.ImageException;
 import org.cotato.csquiz.common.S3.S3Uploader;
 import org.cotato.csquiz.domain.auth.service.MemberService;
+import org.cotato.csquiz.domain.education.util.AnswerUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -289,21 +290,19 @@ public class QuizService {
     @Transactional
     public void addAdditionalAnswer(AddAdditionalAnswerRequest request) {
         Quiz quiz = findQuizById(request.quizId());
+        String processedAnswer = AnswerUtil.processAnswer(request.answer());
         if (quiz instanceof ShortQuiz) {
-            addShortAnswer((ShortQuiz) quiz, request.answer());
+            addShortAnswer((ShortQuiz) quiz, processedAnswer);
         }
         if (quiz instanceof MultipleQuiz) {
-            addCorrectChoice((MultipleQuiz) quiz, request.answer());
+            addCorrectChoice((MultipleQuiz) quiz, processedAnswer);
         }
     }
 
     private void addShortAnswer(ShortQuiz shortQuiz, String answer) {
         checkAnswerAlreadyExist(shortQuiz, answer);
 
-        String cleanedAnswer = answer.toLowerCase()
-                .trim();
-        ShortAnswer shortAnswer = ShortAnswer.of(cleanedAnswer, shortQuiz);
-
+        ShortAnswer shortAnswer = ShortAnswer.of(answer, shortQuiz);
         shortAnswerRepository.save(shortAnswer);
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
@@ -286,6 +286,45 @@ public class QuizService {
                 .toList();
     }
 
+    @Transactional
+    public void addAdditionalAnswer(AddAdditionalAnswerRequest request) {
+        Quiz quiz = findQuizById(request.quizId());
+        if (quiz instanceof ShortQuiz) {
+            addShortAnswer((ShortQuiz) quiz, request.answer());
+        }
+        if (quiz instanceof MultipleQuiz) {
+            addCorrectChoice((MultipleQuiz) quiz, request.answer());
+        }
+    }
+
+    private void addShortAnswer(ShortQuiz shortQuiz, String answer) {
+        checkAnswerAlreadyExist(shortQuiz, answer);
+
+        String cleanedAnswer = answer.toLowerCase()
+                .trim();
+        ShortAnswer shortAnswer = ShortAnswer.of(cleanedAnswer, shortQuiz);
+
+        shortAnswerRepository.save(shortAnswer);
+    }
+
+    private void checkAnswerAlreadyExist(ShortQuiz shortQuiz, String answer) {
+        shortAnswerRepository.findByShortQuizAndContent(shortQuiz, answer)
+                .ifPresent(existingAnswer -> {
+                    throw new AppException(ErrorCode.CONTENT_IS_ALREADY_ANSWER);
+                });
+    }
+
+    private void addCorrectChoice(MultipleQuiz multipleQuiz, String answer) {
+        try {
+            int choiceNumber = Integer.parseInt(answer);
+            Choice choice = choiceRepository.findByMultipleQuizAndChoiceNumber(multipleQuiz, choiceNumber)
+                    .orElseThrow(() -> new EntityNotFoundException("해당 번호의 선지를 찾을 수 없습니다."));
+            choice.updateCorrect(ChoiceCorrect.ANSWER);
+        } catch (NumberFormatException e) {
+            throw new AppException(ErrorCode.INVALID_ANSWER);
+        }
+    }
+
     private Quiz findQuizById(Long quizId) {
         return quizRepository.findById(quizId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 퀴즈를 찾을 수 없습니다."));

--- a/src/main/java/org/cotato/csquiz/domain/education/service/RecordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/RecordService.java
@@ -30,6 +30,7 @@ import org.cotato.csquiz.domain.auth.service.MemberService;
 import org.cotato.csquiz.domain.education.cache.QuizAnswerRedisRepository;
 import org.cotato.csquiz.domain.education.cache.ScorerExistRedisRepository;
 import org.cotato.csquiz.domain.education.cache.TicketCountRedisRepository;
+import org.cotato.csquiz.domain.education.util.AnswerUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,8 +60,7 @@ public class RecordService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
         checkMemberAlreadyCorrect(findQuiz, findMember);
         List<String> inputs = request.inputs().stream()
-                .map(String::toLowerCase)
-                .map(String::trim)
+                .map(AnswerUtil::processAnswer)
                 .sorted()
                 .toList();
 

--- a/src/main/java/org/cotato/csquiz/domain/education/service/RecordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/RecordService.java
@@ -99,6 +99,17 @@ public class RecordService {
         }
     }
 
+    @Transactional
+    public void addAdditionalAnswerToRedis(AddAdditionalAnswerRequest request) {
+        Quiz quiz = findQuizById(request.quizId());
+
+        String cleanedAnswer = request.answer()
+                .toLowerCase()
+                .trim();
+
+        quizAnswerRedisRepository.saveAdditionalQuizAnswer(quiz, cleanedAnswer);
+    }
+
     private Quiz findQuizById(Long quizId) {
         return quizRepository.findById(quizId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 문제를 찾을 수 없습니다."));

--- a/src/main/java/org/cotato/csquiz/domain/education/service/RecordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/RecordService.java
@@ -99,17 +99,6 @@ public class RecordService {
         }
     }
 
-    @Transactional
-    public void addAdditionalAnswerToRedis(AddAdditionalAnswerRequest request) {
-        Quiz quiz = findQuizById(request.quizId());
-
-        String cleanedAnswer = request.answer()
-                .toLowerCase()
-                .trim();
-
-        quizAnswerRedisRepository.saveAdditionalQuizAnswer(quiz, cleanedAnswer);
-    }
-
     private Quiz findQuizById(Long quizId) {
         return quizRepository.findById(quizId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 문제를 찾을 수 없습니다."));

--- a/src/main/java/org/cotato/csquiz/domain/education/service/RecordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/RecordService.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.cotato.csquiz.api.quiz.dto.AddAdditionalAnswerRequest;
 import org.cotato.csquiz.api.record.dto.RecordResponse;
 import org.cotato.csquiz.api.record.dto.RecordsAndScorerResponse;
 import org.cotato.csquiz.api.record.dto.RegradeRequest;
@@ -104,10 +103,11 @@ public class RecordService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 문제를 찾을 수 없습니다."));
     }
 
-    @Transactional
-    public void saveAnswers(QuizOpenRequest request) {
-        scorerExistRedisRepository.saveAllScorerNone(request.educationId());
-        quizAnswerRedisRepository.saveAllQuizAnswers(request.educationId());
+    public void saveAnswersToCache(QuizOpenRequest request) {
+        List<Quiz> quizzes = quizRepository.findAllByEducationId(request.educationId());
+
+        scorerExistRedisRepository.saveAllScorerNone(quizzes);
+        quizAnswerRedisRepository.saveAllQuizAnswers(quizzes);
     }
 
     @Transactional

--- a/src/main/java/org/cotato/csquiz/domain/education/util/AnswerUtil.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/util/AnswerUtil.java
@@ -1,0 +1,8 @@
+package org.cotato.csquiz.domain.education.util;
+
+public class AnswerUtil {
+
+    public static String processAnswer(final String input) {
+        return input.toLowerCase().trim();
+    }
+}


### PR DESCRIPTION
## ✅ 1차 작업 내용

사용하지 않는 2가지 API를 제거함

- 비밀번호 일치 확인 (`/v1/api/member/check/password`): 해당 기능을 다른 API에서 수행하고 있음
- 정답 추가 (`/v1/api/quiz/cs-admin/add`): regrade관련 API만 사용 중임. 

## 🗣 ️리뷰 요구 사항

- 제거한 API와 메서드를 no usage기준으로 지웠는데 남길 필요가 있을지


## ✅ 2차 작업 내용

- 프론트 개발자와 소통 후 정답 추가 (`/v1/api/quiz/cs-admin/add`) API가 사용됨에 따라 커밋 롤백 후 추가
- 이 과정에서 캐시에 정답을 추가하는 로직을 합침
- 주관식 정답 사전 처리 관련 유틸 클래스 생성
- 정답 추가 관련 일부 메서드 이름 변경 (additional을 명시)
- 캐시에 정답을 추가하는 경우 ToCache를 통해 명시적으로 이름 변경
- 캐시 저장 시 중복 조회를 줄이고자 조회 위치 변경


## 🗣 ️리뷰 요구 사항

- 작업 내용 한번씩 읽어주세요~