### PR TITLE
Chore: 기수 목록 및 세션 목록 API 권한 허용

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/config/SecurityConfig.java
+++ b/src/main/java/org/cotato/csquiz/common/config/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/swagger-ui.html",
+            "/v1/api/generation",
+            "/v1/api/session",
             "/websocket/csquiz"
     };
 
@@ -49,7 +51,6 @@ public class SecurityConfig {
         AuthenticationManager authenticationManager = sharedObject.build();
         http.authenticationManager(authenticationManager);
         http.cors();
-
         http.csrf().disable()
                 .cors().disable()
                 .formLogin().disable()
@@ -67,7 +68,6 @@ public class SecurityConfig {
                         .hasAnyRole("MEMBER", "EDUCATION", "ADMIN")
                         .requestMatchers(new AntPathRequestMatcher("/v1/api/education", "GET")).authenticated()
                         .requestMatchers("/v1/api/education/**").hasAnyRole("EDUCATION", "ADMIN")
-                        .requestMatchers("/v1/api/generation").authenticated()
                         .requestMatchers("/v1/api/generation/**").hasAnyRole("ADMIN")
                         .requestMatchers("/v1/api/mypage/**").hasAnyRole("MEMBER", "OLD_MEMBER", "EDUCATION", "ADMIN")
                         .requestMatchers("/v1/api/quiz/cs-admin/**").hasAnyRole("EDUCATION", "ADMIN")

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
@@ -69,6 +69,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         return path.startsWith(AUTH_PATH) || path.equals(LOGIN_PATH)
                 || path.startsWith(SWAGGER_PATH) || path.equals(SWAGGER_FAVICON)
                 || path.startsWith(SWAGGER_PATH_3) || path.startsWith(WS)
-                || path.equals(GENERATION_PATH) || path.startsWith(SESSION_PATH);
+                || path.equals(GENERATION_PATH) || path.equals(SESSION_PATH);
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
@@ -28,7 +28,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private static final String LOGIN_PATH = "/login";
     private static final String SWAGGER_PATH = "/swagger-ui";
     private static final String SWAGGER_PATH_3 = "/v3/api-docs";
+    private static final String SWAGGER_FAVICON = "/favicon.ico";
     private static final String WS = "/websocket/csquiz";
+    private static final String GENERATION_PATH = "/v1/api/generation";
+    private static final String SESSION_PATH = "/v1/api/session";
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
@@ -63,7 +66,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
         log.info("요청 경로: {}", path);
         log.info("요청 메서드: {}", request.getMethod());
-        return path.startsWith(AUTH_PATH) || path.startsWith(LOGIN_PATH)
-                || path.startsWith(SWAGGER_PATH) || path.startsWith(SWAGGER_PATH_3) || path.startsWith(WS);
+        return path.startsWith(AUTH_PATH) || path.equals(LOGIN_PATH)
+                || path.startsWith(SWAGGER_PATH) || path.equals(SWAGGER_FAVICON)
+                || path.startsWith(SWAGGER_PATH_3) || path.startsWith(WS)
+                || path.equals(GENERATION_PATH) || path.startsWith(SESSION_PATH);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용
- 요구 사항이 변함에 따라 '기수 목록 조회' 및 '세션 목록 조회' API의 권한을 전역으로 설정함

## 🗣 ️리뷰 요구 사항
- 변경 사항에 따른 다른 API 의 권한 변경 여부 확인 필요