### PR TITLE
Feature: 세션테이블 '제목' 컬럼 추가

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/session/dto/AddSessionRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/session/dto/AddSessionRequest.java
@@ -12,6 +12,8 @@ public record AddSessionRequest(
         Long generationId,
         MultipartFile sessionImage,
         @NotNull
+        String title,
+        @NotNull
         String description,
         ItIssue itIssue,
         Networking networking,

--- a/src/main/java/org/cotato/csquiz/api/session/dto/SessionListResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/session/dto/SessionListResponse.java
@@ -6,6 +6,7 @@ import org.cotato.csquiz.domain.generation.entity.Session;
 public record SessionListResponse(
         Long sessionId,
         Integer sessionNumber,
+        String title,
         String photoUrl,
         String description,
         Long generationId,
@@ -15,6 +16,7 @@ public record SessionListResponse(
         return new SessionListResponse(
                 session.getId(),
                 session.getNumber(),
+                session.getTitle(),
                 (session.getPhotoS3Info() != null) ? session.getPhotoS3Info().getUrl() : null,
                 session.getDescription(),
                 session.getGeneration().getId(),

--- a/src/main/java/org/cotato/csquiz/api/session/dto/UpdateSessionRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/session/dto/UpdateSessionRequest.java
@@ -13,6 +13,7 @@ public record UpdateSessionRequest(
         MultipartFile sessionImage,
         @NotNull
         Boolean isPhotoUpdated,
+        String title,
         String description,
         @NotNull
         ItIssue itIssue,

--- a/src/main/java/org/cotato/csquiz/domain/generation/entity/Session.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/entity/Session.java
@@ -35,6 +35,9 @@ public class Session extends BaseTimeEntity {
     @Column(name = "session_number")
     private Integer number;
 
+    @Column(name = "session_title", length = 100)
+    private String title;
+
     @Embedded
     private S3Info photoS3Info;
 
@@ -58,9 +61,10 @@ public class Session extends BaseTimeEntity {
     private SessionContents sessionContents;
 
     @Builder
-    public Session(Integer number, S3Info s3Info, String description, Generation generation, SessionContents sessionContents) {
+    public Session(Integer number, S3Info s3Info, String title, String description, Generation generation, SessionContents sessionContents) {
         this.number = number;
         this.photoS3Info = s3Info;
+        this.title = title;
         this.description = description;
         this.generation = generation;
         this.sessionContents = sessionContents;

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/SessionService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/SessionService.java
@@ -55,6 +55,7 @@ public class SessionService {
                 .s3Info(s3Info)
                 .description(request.description())
                 .generation(findGeneration)
+                .title(request.title())
                 .sessionContents(SessionContents.builder()
                         .csEducation(request.csEducation())
                         .devTalk(request.devTalk())


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): https://github.com/IT-Cotato/COTATO-BE/issues/37


## ✅ 작업 내용

- session_title 컬럼 추가
- 길이 100자 제한
- 


## 🗣 ️리뷰 요구 사항
- 세션 추가 API에 '제목' 컬럼을 `@NotNull`로 Validation확인한 것 인지 요망
- 수정에 따른 관련 API 사이드 이펙트 확인