### PR TITLE
Feature: 회원 가입 시 인증에 성공한 이메일만 가입 승인

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/auth/controller/AuthController.java
+++ b/src/main/java/org/cotato/csquiz/api/auth/controller/AuthController.java
@@ -31,7 +31,6 @@ public class AuthController {
 
     @PostMapping("/join")
     public ResponseEntity<Void> joinAuth(@RequestBody @Valid JoinRequest request) {
-        log.info("[회원 가입 컨트롤러]: {}, {}", request.email(), request.name());
         authService.createLoginInfo(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     REQUEST_AGAIN(HttpStatus.NOT_FOUND, "A-202", "해당 이메일에 대한 코드가 존재하지 않습니다. 다시 요청 해주세요"),
     EMAIL_DUPLICATED(HttpStatus.CONFLICT, "A-301", "존재하는 이메일 입니다."),
     PHONE_NUMBER_DUPLICATED(HttpStatus.CONFLICT, "A-302", "존재하는 전화번호입니다."),
+    UNVERIFIED_EMAIL(HttpStatus.UNAUTHORIZED, "A-401", "검증되지 않은 이메일 입니다."),
 
     // 정책 관련
     SHOULD_AGREE_POLICY(HttpStatus.BAD_REQUEST, "P-001", "필수 정책에는 반드시 동의해야합니다."),

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -13,7 +13,6 @@ public enum ErrorCode {
     JWT_FORM_ERROR(HttpStatus.UNAUTHORIZED, "T-003", "jwt 형식 에러 발생"),
     REFRESH_TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED, "T-004", "해당 리프레시 토큰이 DB에 존재하지 않습니다."),
     REISSUE_FAIL(HttpStatus.UNAUTHORIZED, "T-005", "액세스 토큰 재발급 요청 실패"),
-    LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "T-006", "로그인에 실패했습니다."),
 
     // DTO 에서 발생하는 에러
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "I-001", "입력 값이 잘못되었습니다."),

--- a/src/main/java/org/cotato/csquiz/domain/auth/cache/EmailRedisRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/cache/EmailRedisRepository.java
@@ -13,11 +13,11 @@ public class EmailRedisRepository {
     private static final int EXPIRATION_TIME = 15;
     private final RedisTemplate<String, String> redisTemplate;
 
-    public Boolean saveEmail(EmailType type, final String email){
+    public void saveRequestStatus(String status, EmailType type, final String email) {
         String key = type.getKeyPrefix() + email;
-        return redisTemplate.opsForValue().setIfAbsent(
+        redisTemplate.opsForValue().set(
                 key,
-                type.getValue(),
+                status,
                 EXPIRATION_TIME,
                 TimeUnit.MINUTES
         );

--- a/src/main/java/org/cotato/csquiz/domain/auth/cache/EmailRedisRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/cache/EmailRedisRepository.java
@@ -27,4 +27,9 @@ public class EmailRedisRepository {
         String key = type.getKeyPrefix() + email;
         return redisTemplate.hasKey(key);
     }
+
+    public String getValue(EmailType type, final String email) {
+        String key = type.getKeyPrefix() + email;
+        return redisTemplate.opsForValue().get(key);
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
@@ -51,12 +51,16 @@ public class AuthService {
 
     @Transactional
     public void createLoginInfo(JoinRequest request) {
+        if (!emailVerificationService.isSucceedEmail(EmailType.SIGNUP, request.email())) {
+            throw new AppException(ErrorCode.UNVERIFIED_EMAIL);
+        }
         validateService.checkDuplicateEmail(request.email());
         validateService.checkPasswordPattern(request.password());
         validateService.checkPhoneNumber(request.phoneNumber());
 
         String encryptedPhoneNumber = encryptService.encryptPhoneNumber(request.phoneNumber());
         validateService.checkDuplicatePhoneNumber(encryptedPhoneNumber);
+
         log.info("[회원 가입 서비스]: {}, {}", request.email(), request.name());
 
         Member newMember = Member.builder()

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -111,4 +111,8 @@ public class EmailVerificationService {
             throw new AppException(ErrorCode.CODE_NOT_MATCH);
         }
     }
+
+    public boolean isSucceedEmail(EmailType emailType, String email) {
+        return SUCCESS.equals(emailRedisRepository.getValue(emailType, email));
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -31,6 +31,8 @@ public class EmailVerificationService {
 
     private static final int CODE_LENGTH = 6;
     private static final int CODE_BOUNDARY = 10;
+    private static final String SUCCESS = "success";
+    private static final String REQUESTED = "requested";
 
     private final JavaMailSender mailSender;
     private final VerificationCodeRedisRepository verificationCodeRedisRepository;
@@ -43,7 +45,7 @@ public class EmailVerificationService {
         String verificationCode = getVerificationCode();
         log.info("인증 번호 생성 완료");
 
-        emailRedisRepository.saveEmail(type, recipient);
+        emailRedisRepository.saveRequestStatus(REQUESTED, type, recipient);
         verificationCodeRedisRepository.saveCodeWithEmail(type, recipient, verificationCode);
 
         sendEmailWithVerificationCode(recipient, verificationCode, subject);

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -95,6 +95,7 @@ public class EmailVerificationService {
         if (savedVerificationCode != null) {
             validateEmailCodeMatching(savedVerificationCode, code);
             log.info("[이메일 인증 완료]: 성공한 이메일 == {}", email);
+            emailRedisRepository.saveRequestStatus(SUCCESS, type, email);
             return;
         }
 


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용

- [ ] : 검증한 이메일의 상태 설정


## 🗣 ️리뷰 요구 사항

해당 플로우에 대한 고민
1. A 사용자가 이메일 인증
2. 성공
3. B 사용자가 A의 이메일로 회원가입을 시도
4. A보다 B가 먼저 회원 가입 요청

이 경우 A는 이메일 인증을 했지만 회원가입이 불가능해짐
