### PR TITLE
Feature: 기수별 출석 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceAdminController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceAdminController.java
@@ -21,7 +21,7 @@ public class AttendanceAdminController {
     private final AttendanceAdminService attendanceAdminService;
 
     @Operation(summary = "출석 정보 변경 API")
-    @PatchMapping("")
+    @PatchMapping
     public ResponseEntity<Void> updateAttendance(@RequestBody @Valid UpdateAttendanceRequest request) {
         attendanceAdminService.updateAttendance(request);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
@@ -1,6 +1,7 @@
 package org.cotato.csquiz.api.attendance.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -8,8 +9,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.api.attendance.dto.AttendanceRecordResponse;
+import org.cotato.csquiz.api.attendance.dto.AttendancesResponse;
 import org.cotato.csquiz.api.attendance.dto.UpdateAttendanceRequest;
 import org.cotato.csquiz.domain.attendance.service.AttendanceAdminService;
+import org.cotato.csquiz.domain.attendance.service.AttendanceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@Tag(name = "출석 정보", description = "출석 관련 API 입니다.")
 @RestController
 @Validated
 @RequiredArgsConstructor
@@ -28,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AttendanceController {
 
     private final AttendanceAdminService attendanceAdminService;
+    private final AttendanceService attendanceService;
 
     @Operation(summary = "출석 정보 변경 API")
     @PatchMapping
@@ -50,5 +55,11 @@ public class AttendanceController {
     public ResponseEntity<List<AttendanceRecordResponse>> findAttendanceRecordsByAttendance(
             @PathVariable("attendance-id") Long attendanceId) {
         return ResponseEntity.ok().body(attendanceAdminService.findAttendanceRecordsByAttendance(attendanceId));
+    }
+
+    @Operation(summary = "기수별 출석 목록 조회 API")
+    @GetMapping
+    public ResponseEntity<AttendancesResponse> findAttendancesByGeneration(@RequestParam("generationId") Long generationId) {
+        return ResponseEntity.ok().body(attendanceService.findAttendancesByGenerationId(generationId));
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceDeadLineDto.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceDeadLineDto.java
@@ -1,5 +1,8 @@
 package org.cotato.csquiz.api.attendance.dto;
 
+import static org.cotato.csquiz.domain.attendance.constant.DeadLineConstants.DEFAULT_END_TIME;
+import static org.cotato.csquiz.domain.attendance.constant.DeadLineConstants.DEFAULT_START_TIME;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalTime;
 import java.util.Objects;
@@ -11,8 +14,6 @@ public record AttendanceDeadLineDto(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
         LocalTime endTime
 ) {
-    public static final LocalTime DEFAULT_START_TIME = LocalTime.of(19, 0);
-    public static final LocalTime DEFAULT_END_TIME = LocalTime.of(19, 20);
 
     @Builder
     public AttendanceDeadLineDto {

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceDeadLineDto.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceDeadLineDto.java
@@ -1,12 +1,10 @@
 package org.cotato.csquiz.api.attendance.dto;
 
-import static org.cotato.csquiz.domain.attendance.constant.DeadLineConstants.DEFAULT_END_TIME;
-import static org.cotato.csquiz.domain.attendance.constant.DeadLineConstants.DEFAULT_START_TIME;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalTime;
 import java.util.Objects;
 import lombok.Builder;
+import org.cotato.csquiz.domain.attendance.enums.DeadLine;
 
 public record AttendanceDeadLineDto(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
@@ -18,10 +16,10 @@ public record AttendanceDeadLineDto(
     @Builder
     public AttendanceDeadLineDto {
         if (Objects.isNull(attendanceDeadLine)) {
-            attendanceDeadLine = DEFAULT_START_TIME;
+            attendanceDeadLine = DeadLine.DEFAULT_ATTENDANCE_DEADLINE.getTime();
         }
         if (Objects.isNull(lateDeadLine)) {
-            lateDeadLine = DEFAULT_END_TIME;
+            lateDeadLine = DeadLine.DEFAULT_LATE_DEADLINE.getTime();
         }
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceDeadLineDto.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceDeadLineDto.java
@@ -10,18 +10,18 @@ import lombok.Builder;
 
 public record AttendanceDeadLineDto(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
-        LocalTime startTime,
+        LocalTime attendanceDeadLine,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
-        LocalTime endTime
+        LocalTime lateDeadLine
 ) {
 
     @Builder
     public AttendanceDeadLineDto {
-        if (Objects.isNull(startTime)) {
-            startTime = DEFAULT_START_TIME;
+        if (Objects.isNull(attendanceDeadLine)) {
+            attendanceDeadLine = DEFAULT_START_TIME;
         }
-        if (Objects.isNull(endTime)) {
-            endTime = DEFAULT_END_TIME;
+        if (Objects.isNull(lateDeadLine)) {
+            lateDeadLine = DEFAULT_END_TIME;
         }
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceResponse.java
@@ -2,12 +2,13 @@ package org.cotato.csquiz.api.attendance.dto;
 
 import java.time.LocalDate;
 import lombok.Builder;
+import org.cotato.csquiz.domain.attendance.enums.AttendanceOpenStatus;
 
 @Builder
 public record AttendanceResponse(
         Long attendanceId,
         String sessionTitle,
         LocalDate sessionDate,
-        Boolean isOpened
+        AttendanceOpenStatus openStatus
 ) {
 }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceResponse.java
@@ -1,0 +1,13 @@
+package org.cotato.csquiz.api.attendance.dto;
+
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record AttendanceResponse(
+        Long attendanceId,
+        String sessionTitle,
+        LocalDate sessionDate,
+        Boolean isOpened
+) {
+}

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendancesResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendancesResponse.java
@@ -1,0 +1,12 @@
+package org.cotato.csquiz.api.attendance.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AttendancesResponse(
+        Long generationId,
+        Long generationNumber,
+        List<AttendanceResponse> attendances
+) {
+}

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/UpdateAttendanceRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/UpdateAttendanceRequest.java
@@ -1,16 +1,22 @@
 package org.cotato.csquiz.api.attendance.dto;
 
-import jakarta.validation.Valid;
+import static org.cotato.csquiz.domain.attendance.constant.DeadLineConstants.DEFAULT_END_TIME;
+import static org.cotato.csquiz.domain.attendance.constant.DeadLineConstants.DEFAULT_START_TIME;
+
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 import org.cotato.csquiz.domain.attendance.embedded.Location;
 
 public record UpdateAttendanceRequest(
         @NotNull
         Long attendanceId,
         Location location,
-
-        @Valid
-        @NotNull
         AttendanceDeadLineDto attendanceDeadLine
 ) {
+
+    public UpdateAttendanceRequest {
+        if (Objects.isNull(attendanceDeadLine)) {
+            attendanceDeadLine = new AttendanceDeadLineDto(DEFAULT_START_TIME, DEFAULT_END_TIME);
+        }
+    }
 }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/UpdateAttendanceRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/UpdateAttendanceRequest.java
@@ -1,7 +1,7 @@
 package org.cotato.csquiz.api.attendance.dto;
 
-import static org.cotato.csquiz.domain.attendance.constant.DeadLineConstants.DEFAULT_END_TIME;
-import static org.cotato.csquiz.domain.attendance.constant.DeadLineConstants.DEFAULT_START_TIME;
+import static org.cotato.csquiz.domain.attendance.enums.DeadLine.DEFAULT_ATTENDANCE_DEADLINE;
+import static org.cotato.csquiz.domain.attendance.enums.DeadLine.DEFAULT_LATE_DEADLINE;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.Objects;
@@ -16,7 +16,8 @@ public record UpdateAttendanceRequest(
 
     public UpdateAttendanceRequest {
         if (Objects.isNull(attendanceDeadLine)) {
-            attendanceDeadLine = new AttendanceDeadLineDto(DEFAULT_START_TIME, DEFAULT_END_TIME);
+            attendanceDeadLine = new AttendanceDeadLineDto(DEFAULT_ATTENDANCE_DEADLINE.getTime(),
+                    DEFAULT_LATE_DEADLINE.getTime());
         }
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/session/dto/AddSessionRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/session/dto/AddSessionRequest.java
@@ -1,15 +1,15 @@
 package org.cotato.csquiz.api.session.dto;
 
-import jakarta.validation.Valid;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
-import org.cotato.csquiz.domain.attendance.embedded.Location;
-import org.cotato.csquiz.api.attendance.dto.AttendanceDeadLineDto;
 import org.cotato.csquiz.domain.generation.enums.CSEducation;
 import org.cotato.csquiz.domain.generation.enums.DevTalk;
 import org.cotato.csquiz.domain.generation.enums.ItIssue;
 import org.cotato.csquiz.domain.generation.enums.Networking;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
 public record AddSessionRequest(
@@ -20,13 +20,20 @@ public record AddSessionRequest(
         String title,
         @NotNull
         String description,
-        Location location,
+        Double latitude,
+        Double longitude,
         String placeName,
         @NotNull
         LocalDate sessionDate,
-        @Valid
-        @NotNull
-        AttendanceDeadLineDto attendanceDeadLine,
+
+        @Schema(example = "17:00:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        LocalTime startTime,
+
+        @Schema(example = "17:00:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        LocalTime endTime,
+
         ItIssue itIssue,
         Networking networking,
         CSEducation csEducation,

--- a/src/main/java/org/cotato/csquiz/api/session/dto/AddSessionRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/session/dto/AddSessionRequest.java
@@ -28,11 +28,11 @@ public record AddSessionRequest(
 
         @Schema(example = "17:00:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
-        LocalTime startTime,
+        LocalTime attendanceDeadLine,
 
         @Schema(example = "17:00:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
-        LocalTime endTime,
+        LocalTime lateDeadLine,
 
         ItIssue itIssue,
         Networking networking,

--- a/src/main/java/org/cotato/csquiz/domain/attendance/constant/DeadLineConstants.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/constant/DeadLineConstants.java
@@ -1,8 +1,0 @@
-package org.cotato.csquiz.domain.attendance.constant;
-
-import java.time.LocalTime;
-
-public class DeadLineConstants {
-    public static final LocalTime DEFAULT_START_TIME = LocalTime.of(19, 0);
-    public static final LocalTime DEFAULT_END_TIME = LocalTime.of(19, 20);
-}

--- a/src/main/java/org/cotato/csquiz/domain/attendance/constant/DeadLineConstants.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/constant/DeadLineConstants.java
@@ -1,0 +1,8 @@
+package org.cotato.csquiz.domain.attendance.constant;
+
+import java.time.LocalTime;
+
+public class DeadLineConstants {
+    public static final LocalTime DEFAULT_START_TIME = LocalTime.of(19, 0);
+    public static final LocalTime DEFAULT_END_TIME = LocalTime.of(19, 20);
+}

--- a/src/main/java/org/cotato/csquiz/domain/attendance/embedded/Location.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/embedded/Location.java
@@ -2,6 +2,7 @@ package org.cotato.csquiz.domain.attendance.embedded;
 
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,4 +13,10 @@ public class Location {
 
     private Double latitude;
     private Double longitude;
+    
+    @Builder
+    private Location(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/entity/Attendance.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/entity/Attendance.java
@@ -24,11 +24,11 @@ public class Attendance extends BaseTimeEntity {
     @Column(name = "attendance_id")
     private Long id;
 
-    @Column(name = "start_time", nullable = false)
-    private LocalDateTime startTime;
+    @Column(name = "attendance_deadline", nullable = false)
+    private LocalDateTime attendanceDeadLine;
 
-    @Column(name = "end_time", nullable = false)
-    private LocalDateTime endTime;
+    @Column(name = "late_deadline", nullable = false)
+    private LocalDateTime lateDeadLine;
 
     private Location location;
 
@@ -36,9 +36,9 @@ public class Attendance extends BaseTimeEntity {
     private Long sessionId;
 
     @Builder
-    public Attendance(LocalDateTime startTime, LocalDateTime endTime, Location location, Session session) {
-        this.startTime = startTime;
-        this.endTime = endTime;
+    public Attendance(LocalDateTime attendanceDeadLine, LocalDateTime lateDeadLine, Location location, Session session) {
+        this.attendanceDeadLine = attendanceDeadLine;
+        this.lateDeadLine = lateDeadLine;
         this.location = location;
         this.sessionId = session.getId();
     }
@@ -47,8 +47,8 @@ public class Attendance extends BaseTimeEntity {
         this.location = location;
     }
 
-    public void updateDeadLine(LocalDateTime startTime, LocalDateTime endTime) {
-        this.startTime = startTime;
-        this.endTime = endTime;
+    public void updateDeadLine(LocalDateTime attendanceDeadLine, LocalDateTime lateDeadLine) {
+        this.attendanceDeadLine = attendanceDeadLine;
+        this.lateDeadLine = lateDeadLine;
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/enums/AttendanceOpenStatus.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/enums/AttendanceOpenStatus.java
@@ -1,0 +1,16 @@
+package org.cotato.csquiz.domain.attendance.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AttendanceOpenStatus {
+    CLOSED("출결 진행 중이 아닙니다."),
+    OPEN("현재 출석 진행 중"),
+    LATE("현재 출결 입력 시 지각"),
+    ABSENT("현재 출결 입력 시 결석")
+    ;
+
+    private final String description;
+}

--- a/src/main/java/org/cotato/csquiz/domain/attendance/enums/DeadLine.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/enums/DeadLine.java
@@ -1,0 +1,19 @@
+package org.cotato.csquiz.domain.attendance.enums;
+
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DeadLine {
+
+    ATTENDANCE_START_TIME(LocalTime.of(18, 50, 0), "고정 출석 시작 시간"),
+    DEFAULT_ATTENDANCE_DEADLINE(LocalTime.of(19, 5, 59), "기본 출석 마감 시간"),
+    DEFAULT_LATE_DEADLINE(LocalTime.of(19,20,59),"기본 지각 마감 시간"),
+    ATTENDANCE_END_TIME(LocalTime.of(20, 0,0), "고정 세션 종료 시간")
+    ;
+
+    private final LocalTime time;
+    private final String description;
+}

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceAdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceAdminService.java
@@ -35,8 +35,8 @@ public class AttendanceAdminService {
         Attendance attendance = Attendance.builder()
                 .session(session)
                 .location(location)
-                .startTime(LocalDateTime.of(session.getSessionDate(), attendanceDeadLine.startTime()))
-                .endTime(LocalDateTime.of(session.getSessionDate(), attendanceDeadLine.endTime()))
+                .attendanceDeadLine(LocalDateTime.of(session.getSessionDate(), attendanceDeadLine.attendanceDeadLine()))
+                .lateDeadLine(LocalDateTime.of(session.getSessionDate(), attendanceDeadLine.lateDeadLine()))
                 .build();
 
         attendanceRepository.save(attendance);
@@ -55,8 +55,8 @@ public class AttendanceAdminService {
         }
 
         attendance.updateDeadLine(LocalDateTime.of(attendanceSession.getSessionDate(), request.attendanceDeadLine()
-                .startTime()), LocalDateTime.of(attendanceSession.getSessionDate(), request.attendanceDeadLine()
-                .endTime()));
+                .attendanceDeadLine()), LocalDateTime.of(attendanceSession.getSessionDate(), request.attendanceDeadLine()
+                .lateDeadLine()));
         attendance.updateLocation(request.location());
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceAdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceAdminService.java
@@ -2,15 +2,13 @@ package org.cotato.csquiz.domain.attendance.service;
 
 
 import jakarta.persistence.EntityNotFoundException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.api.attendance.dto.AttendanceDeadLineDto;
 import org.cotato.csquiz.api.attendance.dto.AttendanceRecordResponse;
 import org.cotato.csquiz.api.attendance.dto.UpdateAttendanceRequest;
-import org.cotato.csquiz.api.attendance.dto.AttendanceDeadLineDto;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.domain.attendance.embedded.Location;
@@ -78,7 +76,7 @@ public class AttendanceAdminService {
         return attendanceRecordService.generateAttendanceResponses(attendances);
     }
 
-    public List<AttendanceRecordResponse> findAttendanceRecordsByAttendance(Long attendanceId){
+    public List<AttendanceRecordResponse> findAttendanceRecordsByAttendance(Long attendanceId) {
         Attendance attendance = attendanceRepository.findById(attendanceId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 출석이 존재하지 않습니다"));
 

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -1,0 +1,65 @@
+package org.cotato.csquiz.domain.attendance.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.api.attendance.dto.AttendanceResponse;
+import org.cotato.csquiz.api.attendance.dto.AttendancesResponse;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+import org.cotato.csquiz.domain.attendance.entity.Attendance;
+import org.cotato.csquiz.domain.attendance.repository.AttendanceRepository;
+import org.cotato.csquiz.domain.generation.entity.Generation;
+import org.cotato.csquiz.domain.generation.entity.Session;
+import org.cotato.csquiz.domain.generation.repository.GenerationRepository;
+import org.cotato.csquiz.domain.generation.repository.SessionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceService {
+
+    private final AttendanceRepository attendanceRepository;
+    private final SessionRepository sessionRepository;
+    private final GenerationRepository generationRepository;
+
+    @Transactional(readOnly = true)
+    public AttendancesResponse findAttendancesByGenerationId(final Long generationId) {
+        Generation findGeneration = generationRepository.findById(generationId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 기수를 찾을 수 없습니다."));
+
+        List<Session> sessions = sessionRepository.findAllByGenerationId(generationId);
+
+        Map<Long, Session> sessionMap = sessions.stream()
+                .collect(Collectors.toMap(Session::getId, Function.identity()));
+
+        List<Long> sessionIds = sessions.stream()
+                .map(Session::getId)
+                .toList();
+
+        List<AttendanceResponse> attendances = attendanceRepository.findAllBySessionIdsInQuery(sessionIds).stream()
+                .map(at -> AttendanceResponse.builder()
+                        .attendanceId(at.getId())
+                        .sessionTitle(sessionMap.get(at.getSessionId()).getTitle())
+                        .sessionDate(at.getStartTime().toLocalDate())
+                        .isOpened(isAttendanceOpened(at))
+                        .build())
+                .toList();
+
+        return AttendancesResponse.builder()
+                .generationId(generationId)
+                .generationNumber(findGeneration.getId())
+                .attendances(attendances)
+                .build();
+    }
+
+    private boolean isAttendanceOpened(Attendance attendance) {
+        LocalDateTime currentTime = LocalDateTime.now();
+        return currentTime.isAfter(attendance.getStartTime()) && currentTime.isBefore(attendance.getEndTime());
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -46,7 +46,7 @@ public class AttendanceService {
                 .map(at -> AttendanceResponse.builder()
                         .attendanceId(at.getId())
                         .sessionTitle(sessionMap.get(at.getSessionId()).getTitle())
-                        .sessionDate(at.getStartTime().toLocalDate())
+                        .sessionDate(at.getAttendanceDeadLine().toLocalDate())
                         .isOpened(isAttendanceOpened(at))
                         .build())
                 .toList();
@@ -60,6 +60,6 @@ public class AttendanceService {
 
     private boolean isAttendanceOpened(Attendance attendance) {
         LocalDateTime currentTime = LocalDateTime.now();
-        return currentTime.isAfter(attendance.getStartTime()) && currentTime.isBefore(attendance.getEndTime());
+        return currentTime.isAfter(attendance.getAttendanceDeadLine()) && currentTime.isBefore(attendance.getLateDeadLine());
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -9,8 +9,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.api.attendance.dto.AttendanceResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendancesResponse;
-import org.cotato.csquiz.common.error.ErrorCode;
-import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.domain.attendance.entity.Attendance;
 import org.cotato.csquiz.domain.attendance.repository.AttendanceRepository;
 import org.cotato.csquiz.domain.generation.entity.Generation;

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -60,7 +60,7 @@ public class AttendanceService {
     }
 
     private AttendanceOpenStatus getAttendanceStatus(Attendance attendance) {
-        if (!isToday(attendance) || !isStarted(attendance)) {
+        if (!isToday(attendance) || !isStarted()) {
             return AttendanceOpenStatus.CLOSED;
         }
 
@@ -83,7 +83,7 @@ public class AttendanceService {
         return LocalDate.now().equals(attendance.getAttendanceDeadLine().toLocalDate());
     }
 
-    private boolean isStarted(Attendance attendance) {
-        return LocalTime.now().isBefore(attendance.getAttendanceDeadLine().toLocalTime());
+    private boolean isStarted() {
+        return LocalTime.now().isBefore(DeadLine.ATTENDANCE_START_TIME.getTime());
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -66,13 +66,13 @@ public class AttendanceService {
 
         LocalTime currentTime = LocalTime.now();
 
-        if (currentTime.isAfter(attendance.getAttendanceDeadLine().toLocalTime())
-                && currentTime.isBefore(attendance.getLateDeadLine().toLocalTime())) {
+        if (currentTime.isAfter(DeadLine.ATTENDANCE_START_TIME.getTime())
+                && currentTime.isBefore(attendance.getAttendanceDeadLine().toLocalTime())) {
             return AttendanceOpenStatus.OPEN;
         }
 
-        if (currentTime.isAfter(attendance.getLateDeadLine().toLocalTime())
-                && currentTime.isBefore(DeadLine.ATTENDANCE_END_TIME.getTime())) {
+        if (currentTime.isAfter(attendance.getAttendanceDeadLine().toLocalTime())
+                && currentTime.isBefore(attendance.getLateDeadLine().toLocalTime())) {
             return AttendanceOpenStatus.LATE;
         }
 

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/SessionService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/SessionService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.api.attendance.dto.AttendanceDeadLineDto;
 import org.cotato.csquiz.api.session.dto.AddSessionRequest;
 import org.cotato.csquiz.api.session.dto.AddSessionResponse;
 import org.cotato.csquiz.api.session.dto.CsEducationOnSessionNumberResponse;
@@ -13,6 +14,7 @@ import org.cotato.csquiz.api.session.dto.SessionListResponse;
 import org.cotato.csquiz.api.session.dto.UpdateSessionNumberRequest;
 import org.cotato.csquiz.api.session.dto.UpdateSessionRequest;
 import org.cotato.csquiz.common.error.exception.ImageException;
+import org.cotato.csquiz.domain.attendance.embedded.Location;
 import org.cotato.csquiz.domain.attendance.service.AttendanceAdminService;
 import org.cotato.csquiz.domain.education.entity.Education;
 import org.cotato.csquiz.domain.education.service.EducationService;
@@ -69,7 +71,17 @@ public class SessionService {
             sessionImageService.addSessionImages(request.images(), savedSession);
         }
 
-        attendanceAdminService.addAttendance(session, request.location(), request.attendanceDeadLine());
+        Location location = Location.builder()
+                .latitude(request.latitude())
+                .longitude(request.longitude())
+                .build();
+
+        AttendanceDeadLineDto attendanceDeadLine = AttendanceDeadLineDto.builder()
+                .startTime(request.startTime())
+                .endTime(request.endTime())
+                .build();
+
+        attendanceAdminService.addAttendance(session, location, attendanceDeadLine);
 
         return AddSessionResponse.from(savedSession);
     }

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/SessionService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/SessionService.java
@@ -87,7 +87,7 @@ public class SessionService {
     }
 
     private int calculateLastSessionNumber(Generation generation) {
-        List<Session> allSession = sessionRepository.findAllByGeneration(generation);
+        List<Session> allSession = sessionRepository.findAllByGenerationId(generation.getId());
         return allSession.stream().mapToInt(Session::getNumber).max()
                 .orElse(-1);
     }

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/SessionService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/SessionService.java
@@ -77,8 +77,8 @@ public class SessionService {
                 .build();
 
         AttendanceDeadLineDto attendanceDeadLine = AttendanceDeadLineDto.builder()
-                .startTime(request.startTime())
-                .endTime(request.endTime())
+                .attendanceDeadLine(request.attendanceDeadLine())
+                .lateDeadLine(request.lateDeadLine())
                 .build();
 
         attendanceAdminService.addAttendance(session, location, attendanceDeadLine);


### PR DESCRIPTION
## ✅ 작업 내용

- [x] : 기수별 출석 목록 조회 API 구현


## 🗣 ️리뷰 요구 사항

현재 출석과 세션은 1:1 관계임.
'출석 목록' 조회를 하다보니 '세션 제목'이라는 세션 값 조회가 필수라는 것을 느낌.

Join을 계속 하는 것이 성능적으로 괜찮을까에 대한 고민이 있음

두 테이블의 역정규화를 통해 다시 합치는게 어떠할지에 대한 의견 부탁합니다.