### PR TITLE
Refactor: S3 예외 코드 분리 및 에러 메세지 변경

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/S3/S3Uploader.java
+++ b/src/main/java/org/cotato/csquiz/common/S3/S3Uploader.java
@@ -86,7 +86,7 @@ public class S3Uploader {
 
             return convertFile;
         } catch (IOException e) {
-            throw new ImageException(ErrorCode.IMAGE_PROCESSING_FAIL);
+            throw new ImageException(ErrorCode.IMAGE_CONVERT_FAIL);
         }
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -56,7 +56,7 @@ public enum ErrorCode {
     SESSION_IMAGE_COUNT_MISMATCH(HttpStatus.BAD_REQUEST, "P-101", "저장된 사진 수와 요청 사진 수가 다릅니다."),
     SESSION_ORDER_INVALID(HttpStatus.BAD_REQUEST, "P-102", "입력한 순서는 유효하지 않습니다."),
 
-    FILE_EXTENSION_FAULT(HttpStatus.BAD_REQUEST, "F-001", "해당 파일은 등록 할 수 없는 확장자명입니다."),
+    FILE_EXTENSION_FAULT(HttpStatus.BAD_REQUEST, "F-001", "해당 파일 확장자 명이 존재하지 않습니다."),
     FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "F-002", "파일이 비어있습니다"),
 
     INVALID_ANSWER(HttpStatus.BAD_REQUEST, "Q-101", "객관식 문제는 숫자 형식의 값만 정답으로 추가할 수 있습니다."),
@@ -91,6 +91,7 @@ public enum ErrorCode {
     INTERNAL_SQL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-004", "SQL 관련 에러 발생"),
     ENUM_NOT_RESOLVED(HttpStatus.BAD_REQUEST, "S-005", "입력한 Enum이 존재하지 않습니다."),
     SCORER_LOCK_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-006", "득점자 락 획득 과정에서 에러 발생"),
+    IMAGE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-007", "로컬 이미지 변환에 실패했습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/cotato/csquiz/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/cotato/csquiz/common/error/handler/GlobalExceptionHandler.java
@@ -90,8 +90,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAmazonS3Exception(AmazonS3Exception e, HttpServletRequest request) {
         log.error("발생한 에러: {}", e.getErrorCode());
         log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
-        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.FILE_EXTENSION_FAULT, request);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.IMAGE_PROCESSING_FAIL, request);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }
 }
 


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용
- convert 에러 -> IMAGE_CONVERT_FAIL 로 변경
- AmazonS3Exception 이 기존의 IMAGE_PROCESSING_FAIL 사용
- 확장자가 없을 때 예외 메세지 변경

## 🗣 ️리뷰 요구 사항