### PR TITLE
Feature: 프로젝트 목록 반환 시 url 관련 정보 추가

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/project/dto/ProjectSummaryResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/project/dto/ProjectSummaryResponse.java
@@ -9,7 +9,10 @@ public record ProjectSummaryResponse(
         String introduction,
         Long generationId,
         Integer generationNumber,
-        String imageUrl
+        String imageUrl,
+        String githubUrl,
+        String behanceUrl,
+        String projectUrl
 ) {
     public static ProjectSummaryResponse of(Project project, Integer generationNumber, ProjectImage projectImage) {
         return new ProjectSummaryResponse(
@@ -18,7 +21,10 @@ public record ProjectSummaryResponse(
                 project.getIntroduction(),
                 project.getGenerationId(),
                 generationNumber,
-                projectImage != null ? projectImage.getS3Info().getUrl() : null
+                projectImage != null ? projectImage.getS3Info().getUrl() : null,
+                project.getGithubUrl(),
+                project.getBehanceUrl(),
+                project.getProjectUrl()
         );
     }
 }


### PR DESCRIPTION

## ✅ 작업 내용
- ProjectSummaryResponse에 url 관련 정보 추가

## 테스트 사진
<img width="630" alt="스크린샷 2024-08-18 오후 4 06 21" src="https://github.com/user-attachments/assets/ce203da6-50ae-4732-a785-16d1b8f7db26">
