### PR TITLE
Fix: 중복된 순서 저장을 방지하기 위해 요청에 순서를 명시하게 변경

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/session/dto/AddSessionImageRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/session/dto/AddSessionImageRequest.java
@@ -8,6 +8,8 @@ public record AddSessionImageRequest(
         @NotNull
         Long sessionId,
         @NotNull
-        MultipartFile image
+        MultipartFile image,
+        @NotNull
+        Integer order
 ) {
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/repository/SessionImageRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/repository/SessionImageRepository.java
@@ -1,7 +1,6 @@
 package org.cotato.csquiz.domain.generation.repository;
 
 import java.util.List;
-import java.util.Optional;
 import org.cotato.csquiz.domain.generation.entity.Session;
 import org.cotato.csquiz.domain.generation.entity.SessionImage;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +10,5 @@ public interface SessionImageRepository extends JpaRepository<SessionImage, Long
 
     List<SessionImage> findAllBySessionIn(List<Session> sessions);
 
-    Optional<SessionImage> findFirstBySessionOrderByOrderDesc(Session session);
+    boolean existsBySessionAndOrder(Session session, Integer order);
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/SessionImageService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/SessionImageService.java
@@ -67,13 +67,14 @@ public class SessionImageService {
 
         S3Info imageInfo = s3Uploader.uploadFiles(request.image(), SESSION_BUCKET_DIRECTORY);
 
-        Integer imageOrder = sessionImageRepository.findFirstBySessionOrderByOrderDesc(session)
-                .map(sessionImage -> sessionImage.getOrder() + 1).orElse(0);
+        if (sessionImageRepository.existsBySessionAndOrder(session, request.order())) {
+            throw new AppException(ErrorCode.SESSION_ORDER_INVALID);
+        }
 
         SessionImage sessionImage = SessionImage.builder()
                 .session(session)
                 .s3Info(imageInfo)
-                .order(imageOrder)
+                .order(request.order())
                 .build();
 
         return AddSessionImageResponse.from(sessionImageRepository.save(sessionImage));


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용
- 세션 사진 추가 시 중복된 순서 저장을 방지하기 위해 request에 order를 명시하게 변경

## 🗣 ️리뷰 요구 사항