### PR TITLE
Fix: 기존에 등록된 프로젝트에 이미지 추가 시 예외처리 발생하지 않던 에러 해결

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -84,6 +84,10 @@ public enum ErrorCode {
     ALREADY_ATTEND(HttpStatus.CONFLICT, "AT-301", "이미 해당 타입으로 출석한 기록이 있습니다."),
     ATTENDANCE_NOT_OPEN(HttpStatus.BAD_REQUEST, "AT-401", "출석 시간이 아닙니다."),
 
+    //프로젝트 관련
+    LOGO_IMAGE_EXIST(HttpStatus.CONFLICT, "PJ-301", "이미 로고 이미지가 존재합니다."),
+    THUMBNAIL_IMAGE_EXIST(HttpStatus.CONFLICT, "PJ-302", "이미 썸네일 이미지가 존재합니다."),
+
     // 500 오류 -> 서버측에서 처리가 실패한 부분들
     WEBSOCKET_SEND_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "S-001", "소캣 메세지 전송 실패"),
     IMAGE_PROCESSING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-002", "이미지 처리에 실패했습니다."),

--- a/src/main/java/org/cotato/csquiz/domain/generation/entity/Project.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/entity/Project.java
@@ -9,11 +9,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.cotato.csquiz.common.entity.BaseTimeEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Project {
+public class Project extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/cotato/csquiz/domain/generation/entity/ProjectImage.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/entity/ProjectImage.java
@@ -49,7 +49,7 @@ public class ProjectImage {
                 ProjectImageType.LOGO,
                 s3Info,
                 projectId,
-                1);
+                0);
     }
 
     public static ProjectImage thumbnailImage(S3Info s3Info, Long projectId) {
@@ -57,7 +57,7 @@ public class ProjectImage {
                 ProjectImageType.THUMBNAIL,
                 s3Info,
                 projectId,
-                1);
+                0);
     }
 
     public static ProjectImage detailImage(S3Info imageInfo, Long projectId, int imageOrder) {

--- a/src/main/java/org/cotato/csquiz/domain/generation/entity/ProjectImage.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/entity/ProjectImage.java
@@ -11,13 +11,14 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.cotato.csquiz.common.entity.BaseTimeEntity;
 import org.cotato.csquiz.common.entity.S3Info;
 import org.cotato.csquiz.domain.generation.enums.ProjectImageType;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProjectImage {
+public class ProjectImage extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/cotato/csquiz/domain/generation/entity/ProjectMember.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/entity/ProjectMember.java
@@ -11,12 +11,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.cotato.csquiz.common.entity.BaseTimeEntity;
 import org.cotato.csquiz.domain.auth.enums.MemberPosition;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProjectMember {
+public class ProjectMember extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/cotato/csquiz/domain/generation/repository/ProjectImageRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/repository/ProjectImageRepository.java
@@ -1,11 +1,9 @@
 package org.cotato.csquiz.domain.generation.repository;
 
 import java.util.List;
-import java.util.Optional;
 import org.cotato.csquiz.domain.generation.entity.ProjectImage;
 import org.cotato.csquiz.domain.generation.enums.ProjectImageType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ProjectImageRepository extends JpaRepository<ProjectImage, Long> {
     List<ProjectImage> findAllByProjectId(Long projectId);

--- a/src/main/java/org/cotato/csquiz/domain/generation/repository/ProjectImageRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/repository/ProjectImageRepository.java
@@ -11,9 +11,5 @@ public interface ProjectImageRepository extends JpaRepository<ProjectImage, Long
     List<ProjectImage> findAllByProjectId(Long projectId);
     List<ProjectImage> findAllByProjectIdInAndProjectImageType(List<Long> projectIds, ProjectImageType projectImageType);
 
-    @Query("SELECT p FROM ProjectImage p WHERE p.projectId = :projectId AND p.projectImageType = 'LOGO'")
-    Optional<ProjectImage> findLogoImageByProjectId(Long projectId);
-
-    @Query("SELECT p FROM ProjectImage p WHERE p.projectId = :projectId AND p.projectImageType = 'THUMBNAIL'")
-    Optional<ProjectImage> findThumbnailImageByProjectId(Long projectId);
+    boolean existsByProjectIdAndProjectImageType(Long projectId, ProjectImageType projectImageType);
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/repository/ProjectImageRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/repository/ProjectImageRepository.java
@@ -1,11 +1,19 @@
 package org.cotato.csquiz.domain.generation.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.cotato.csquiz.domain.generation.entity.ProjectImage;
 import org.cotato.csquiz.domain.generation.enums.ProjectImageType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProjectImageRepository extends JpaRepository<ProjectImage, Long> {
     List<ProjectImage> findAllByProjectId(Long projectId);
     List<ProjectImage> findAllByProjectIdInAndProjectImageType(List<Long> projectIds, ProjectImageType projectImageType);
+
+    @Query("SELECT p FROM ProjectImage p WHERE p.projectId = :projectId AND p.projectImageType = 'LOGO'")
+    Optional<ProjectImage> findLogoImageByProjectId(Long projectId);
+
+    @Query("SELECT p FROM ProjectImage p WHERE p.projectId = :projectId AND p.projectImageType = 'THUMBNAIL'")
+    Optional<ProjectImage> findThumbnailImageByProjectId(Long projectId);
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/ProjectImageService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/ProjectImageService.java
@@ -39,8 +39,8 @@ public class ProjectImageService {
         newImages.add(ProjectImage.thumbnailImage(thumbNailInfo, projectId));
 
         if (detailImages != null && !detailImages.isEmpty()) {
-            for (int orderIndex = 1; orderIndex <= detailImages.size(); orderIndex++) {
-                MultipartFile detailImage = detailImages.get(orderIndex - 1);
+            for (int orderIndex = 0; orderIndex < detailImages.size(); orderIndex++) {
+                MultipartFile detailImage = detailImages.get(orderIndex);
                 File webpDetailImage = convertToWebp(convert(detailImage));
                 S3Info detailImageInfo = s3Uploader.uploadFiles(webpDetailImage, PROJECT_IMAGE);
                 newImages.add(ProjectImage.detailImage(detailImageInfo, projectId, orderIndex));

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/ProjectImageService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/ProjectImageService.java
@@ -6,7 +6,6 @@ import static org.cotato.csquiz.common.util.FileUtil.convertToWebp;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.common.entity.S3Info;
 import org.cotato.csquiz.common.error.ErrorCode;
@@ -14,6 +13,7 @@ import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.common.error.exception.ImageException;
 import org.cotato.csquiz.common.s3.S3Uploader;
 import org.cotato.csquiz.domain.generation.entity.ProjectImage;
+import org.cotato.csquiz.domain.generation.enums.ProjectImageType;
 import org.cotato.csquiz.domain.generation.repository.ProjectImageRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,15 +31,8 @@ public class ProjectImageService {
     public void createProjectImage(Long projectId, MultipartFile logoImage, MultipartFile thumbNailImage,
                                    List<MultipartFile> detailImages) throws ImageException {
 
-        Optional<ProjectImage> existingLogoImage = projectImageRepository.findLogoImageByProjectId(projectId);
-        if (existingLogoImage.isPresent()) {
-            throw new AppException(ErrorCode.LOGO_IMAGE_EXIST);
-        }
-
-        Optional<ProjectImage> existingThumbnailImage = projectImageRepository.findThumbnailImageByProjectId(projectId);
-        if (existingThumbnailImage.isPresent()) {
-            throw new AppException(ErrorCode.THUMBNAIL_IMAGE_EXIST);
-        }
+        validateLogoImageExistence(projectId);
+        validateThumbNailImageExistence(projectId);
 
         List<ProjectImage> newImages = new ArrayList<>();
 
@@ -61,5 +54,17 @@ public class ProjectImageService {
         }
 
         projectImageRepository.saveAll(newImages);
+    }
+
+    private void validateThumbNailImageExistence(Long projectId) {
+        if (projectImageRepository.existsByProjectIdAndProjectImageType(projectId, ProjectImageType.THUMBNAIL)) {
+            throw new AppException(ErrorCode.THUMBNAIL_IMAGE_EXIST);
+        }
+    }
+
+    private void validateLogoImageExistence(Long projectId) {
+        if (projectImageRepository.existsByProjectIdAndProjectImageType(projectId, ProjectImageType.LOGO)) {
+            throw new AppException(ErrorCode.LOGO_IMAGE_EXIST);
+        }
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/ProjectImageService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/ProjectImageService.java
@@ -6,8 +6,11 @@ import static org.cotato.csquiz.common.util.FileUtil.convertToWebp;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.common.entity.S3Info;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.common.error.exception.ImageException;
 import org.cotato.csquiz.common.s3.S3Uploader;
 import org.cotato.csquiz.domain.generation.entity.ProjectImage;
@@ -26,8 +29,18 @@ public class ProjectImageService {
 
     @Transactional
     public void createProjectImage(Long projectId, MultipartFile logoImage, MultipartFile thumbNailImage,
-                                   List<MultipartFile> detailImages)
-            throws ImageException {
+                                   List<MultipartFile> detailImages) throws ImageException {
+
+        Optional<ProjectImage> existingLogoImage = projectImageRepository.findLogoImageByProjectId(projectId);
+        if (existingLogoImage.isPresent()) {
+            throw new AppException(ErrorCode.LOGO_IMAGE_EXIST);
+        }
+
+        Optional<ProjectImage> existingThumbnailImage = projectImageRepository.findThumbnailImageByProjectId(projectId);
+        if (existingThumbnailImage.isPresent()) {
+            throw new AppException(ErrorCode.THUMBNAIL_IMAGE_EXIST);
+        }
+
         List<ProjectImage> newImages = new ArrayList<>();
 
         File webpLogoImage = convertToWebp(convert(logoImage));


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): https://github.com/IT-Cotato/COTATO-BE/issues/156#issue-2533951853


## ✅ 작업 내용
- 프로젝트 추가 간에 검증 로직 및 예외 사항 핸들링 할 것
- extends로 BaseTimeEntity를 프로젝트, 프로젝트 이미지, 프로젝트 멤버에 달기
- order 0부터 시작하게 바꾸기

## SQL문

### 기존에 있는 프로젝트 이미지 순서를 바꾸기 위한 쿼리 (주석 반드시 확인 바랍니다!!)

```SQL
UPDATE project_image pi
    JOIN (
        SELECT project_image_id,
               ROW_NUMBER() OVER (PARTITION BY project_id ORDER BY project_image_id) - 1 AS new_order
        FROM project_image
        WHERE project_image_type = 'DETAIL' -- project_image_type를 지정
    ) AS ordered_images
    ON pi.project_image_id = ordered_images.project_image_id
SET pi.project_image_order = ordered_images.new_order
WHERE pi.project_id = 1;  -- project_id를 지정
```

### Project, ProjectImage, ProjectMember 테이블에 컬럼 추가:

```SQL
ALTER TABLE Project
ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;

ALTER TABLE ProjectImage
ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;

ALTER TABLE ProjectMember
ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
```