### PR TITLE
Feature: 디스코드 봇을 활용한 1일 1 퀴즈 풀이 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
 
+    // discord 봇 관련 레포
+    implementation group: 'net.dv8tion', name: 'JDA', version: '5.1.1'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/cotato/csquiz/common/config/JdaConfig.java
+++ b/src/main/java/org/cotato/csquiz/common/config/JdaConfig.java
@@ -1,19 +1,26 @@
 package org.cotato.csquiz.common.config;
 
+import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import org.cotato.csquiz.domain.education.service.DiscordButtonListener;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class JdaConfig {
+
+    private final DiscordButtonListener discordButtonListener;
 
     @Value("${discord.bot.token}")
     private String botToken;
 
     @Bean
     public JDA jda() throws InterruptedException {
-        return JDABuilder.createDefault(botToken).build().awaitReady();
+        return JDABuilder.createDefault(botToken)
+                .addEventListeners(discordButtonListener)
+                .build().awaitReady();
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/config/JdaConfig.java
+++ b/src/main/java/org/cotato/csquiz/common/config/JdaConfig.java
@@ -1,0 +1,19 @@
+package org.cotato.csquiz.common.config;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JdaConfig {
+
+    @Value("${discord.bot.token}")
+    private String botToken;
+
+    @Bean
+    public JDA jda() throws InterruptedException {
+        return JDABuilder.createDefault(botToken).build().awaitReady();
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -97,7 +97,10 @@ public enum ErrorCode {
     SCORER_LOCK_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-006", "득점자 락 획득 과정에서 에러 발생"),
     IMAGE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-007", "로컬 이미지 변환에 실패했습니다"),
     SSE_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-008", "서버 이벤트 전송간 오류 발생"),
-    WEBP_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-009", "webp 변환에 실패했습니다")
+    WEBP_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-009", "webp 변환에 실패했습니다"),
+    GUILD_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "S-010", "디스코드 서버를 찾지 못했습니다."),
+    CHANNEL_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "S-011", "디스코드 채널을 찾지 못했습니다."),
+    DISCORD_BUTTON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-012" , "디스코드 버튼 이벤트 ID를 찾지 못했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/cotato/csquiz/domain/education/cache/DiscordQuizRedisRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/cache/DiscordQuizRedisRepository.java
@@ -1,0 +1,34 @@
+package org.cotato.csquiz.domain.education.cache;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DiscordQuizRedisRepository {
+
+    private static final String KEY_PREFIX = "$discord_quiz";
+    private static final long QUIZ_EXPIRATION = 7 * 24 * 60;
+    private static final long EXISTS_VALUE = 1;
+    private final RedisTemplate<String, Long> redisTemplate;
+
+    public void save(Long quizId) {
+        redisTemplate.opsForValue().set(
+                generateKey(quizId),
+                EXISTS_VALUE,
+                QUIZ_EXPIRATION,
+                TimeUnit.MINUTES
+        );
+    }
+
+    public boolean isUsedInOneWeek(Long quizId){
+        return Objects.equals(redisTemplate.opsForValue().get(generateKey(quizId)), EXISTS_VALUE);
+    }
+
+    private String generateKey(Long quizId) {
+        return KEY_PREFIX + quizId;
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/enums/QuizType.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/enums/QuizType.java
@@ -1,7 +1,9 @@
 package org.cotato.csquiz.domain.education.enums;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public enum QuizType {
     MULTIPLE_QUIZ("객관식 문제"),

--- a/src/main/java/org/cotato/csquiz/domain/education/repository/ChoiceRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/repository/ChoiceRepository.java
@@ -19,4 +19,6 @@ public interface ChoiceRepository extends JpaRepository<Choice, Long> {
     @Modifying
     @Query("delete from Choice c where c.multipleQuiz.id in :quizIds")
     void deleteAllByQuizIdsInQuery(@Param("quizIds") List<Long> quizIds);
+
+    List<Choice> findAllByMultipleQuizId(Long quizId);
 }

--- a/src/main/java/org/cotato/csquiz/domain/education/repository/EducationRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/repository/EducationRepository.java
@@ -2,6 +2,7 @@ package org.cotato.csquiz.domain.education.repository;
 
 import org.cotato.csquiz.domain.education.entity.Education;
 import java.util.List;
+import org.cotato.csquiz.domain.education.enums.EducationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,5 @@ public interface EducationRepository extends JpaRepository<Education, Long> {
     boolean existsBySessionId(Long sessionId);
 
     List<Education> findAllByGenerationId(Long generationId);
+    List<Education> findAllByStatus(EducationStatus status);
 }

--- a/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
@@ -1,0 +1,31 @@
+package org.cotato.csquiz.domain.education.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.domain.education.service.ChoiceService;
+import org.cotato.csquiz.domain.education.service.DiscordService;
+import org.cotato.csquiz.domain.education.service.QuizService;
+import org.cotato.csquiz.domain.education.service.dto.RandomQuizResponse;
+import org.cotato.csquiz.domain.education.util.DiscordUtil;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuizScheduler {
+
+    private final DiscordService discordService;
+    private final QuizService quizService;
+    private final ChoiceService choiceService;
+
+    @Transactional(readOnly = true)
+    @Scheduled(cron = "0 0 14 * * ?")
+    public void sendRandomQuiz() {
+        RandomQuizResponse randomQuiz = quizService.pickRandomQuiz();
+        discordService.sendMessageToTextChannel(DiscordUtil.getMultipleQuizEmbeds(randomQuiz),
+                DiscordUtil.getButtons(choiceService.findAllChoices(randomQuiz.id())));
+        log.info("[디스코드 채널 문제 전송 완료: {}]", randomQuiz.id());
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/service/ChoiceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/ChoiceService.java
@@ -1,0 +1,22 @@
+package org.cotato.csquiz.domain.education.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.api.quiz.dto.ChoiceResponse;
+import org.cotato.csquiz.domain.education.repository.ChoiceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChoiceService {
+
+    private final ChoiceRepository choiceRepository;
+
+    @Transactional(readOnly = true)
+    public List<ChoiceResponse> findAllChoices(Long multipleQuizId) {
+        return choiceRepository.findAllByMultipleQuizId(multipleQuizId).stream()
+                .map(ChoiceResponse::forEducation)
+                .toList();
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/service/DiscordButtonListener.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/DiscordButtonListener.java
@@ -1,0 +1,35 @@
+package org.cotato.csquiz.domain.education.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+import org.cotato.csquiz.domain.education.entity.Choice;
+import org.cotato.csquiz.domain.education.enums.ChoiceCorrect;
+import org.cotato.csquiz.domain.education.repository.ChoiceRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordButtonListener extends ListenerAdapter {
+
+    private final ChoiceRepository choiceRepository;
+
+    @Override
+    public void onButtonInteraction(ButtonInteractionEvent event) {
+        String id = Optional.ofNullable(event.getButton().getId())
+                .orElseThrow(() -> new AppException(ErrorCode.DISCORD_BUTTON_ERROR));
+
+        Choice choice = choiceRepository.findById(Long.parseLong(id))
+                .orElseThrow(() -> new EntityNotFoundException("해당 선지를 찾을 수 없습니다."));
+
+        if (choice.getIsCorrect() == ChoiceCorrect.ANSWER) {
+            event.reply("축하합니다! 정답입니다.").queue();
+        } else {
+            event.reply("아쉽게도 오답이네요 ㅠ").queue();
+        }
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/service/DiscordButtonListener.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/DiscordButtonListener.java
@@ -30,9 +30,9 @@ public class DiscordButtonListener extends ListenerAdapter {
                 .orElseThrow(() -> new EntityNotFoundException("해당 선지를 찾을 수 없습니다."));
 
         if (choice.getIsCorrect() == ChoiceCorrect.ANSWER) {
-            event.reply("축하합니다! 정답입니다.").queue();
+            event.deferReply(true).setContent("축하합니다! 정답입니다.").queue();
         } else {
-            event.reply("아쉽게도 오답이네요 ㅠ").queue();
+            event.deferReply(true).setContent("아쉽게도 오답이네요 ㅠ").queue();
         }
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/education/service/DiscordButtonListener.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/DiscordButtonListener.java
@@ -3,6 +3,7 @@ package org.cotato.csquiz.domain.education.service;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.cotato.csquiz.common.error.ErrorCode;
@@ -12,6 +13,7 @@ import org.cotato.csquiz.domain.education.enums.ChoiceCorrect;
 import org.cotato.csquiz.domain.education.repository.ChoiceRepository;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DiscordButtonListener extends ListenerAdapter {
@@ -22,6 +24,7 @@ public class DiscordButtonListener extends ListenerAdapter {
     public void onButtonInteraction(ButtonInteractionEvent event) {
         String id = Optional.ofNullable(event.getButton().getId())
                 .orElseThrow(() -> new AppException(ErrorCode.DISCORD_BUTTON_ERROR));
+        log.info("[디스 코드 리스너 전송: {}]", id);
 
         Choice choice = choiceRepository.findById(Long.parseLong(id))
                 .orElseThrow(() -> new EntityNotFoundException("해당 선지를 찾을 수 없습니다."));

--- a/src/main/java/org/cotato/csquiz/domain/education/service/DiscordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/DiscordService.java
@@ -1,0 +1,44 @@
+package org.cotato.csquiz.domain.education.service;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordService {
+
+    private final JDA jda;
+
+    @Value("${discord.guild.id}")
+    private String guildId;
+
+    @Value("${discord.channel.id}")
+    private String channelId;
+
+    public void sendMessageToTextChannel(MessageEmbed messageEmbed, List<Button> buttons) {
+        Guild guild = Optional.ofNullable(jda.getGuildById(guildId))
+                .orElseThrow(() -> new AppException(ErrorCode.GUILD_NOT_FOUND));
+        TextChannel channel = Optional.ofNullable(guild.getChannelById(TextChannel.class, channelId))
+                .orElseThrow(() -> new AppException(ErrorCode.CHANNEL_NOT_FOUND));
+
+        if (channel.canTalk()) {
+            channel.sendMessageEmbeds(messageEmbed)
+                    .setActionRow(buttons)
+                    .queue();
+        } else {
+            log.warn("채널에 메시지를 보낼 수 없음.");
+        }
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/service/dto/RandomQuizResponse.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/dto/RandomQuizResponse.java
@@ -1,0 +1,22 @@
+package org.cotato.csquiz.domain.education.service.dto;
+
+import org.cotato.csquiz.domain.education.entity.Quiz;
+import org.cotato.csquiz.domain.education.enums.QuizType;
+
+public record RandomQuizResponse(
+        Long id,
+        int number,
+        QuizType quizType,
+        String question,
+        String imageUrl
+) {
+    public static RandomQuizResponse from(Quiz quiz) {
+        return new RandomQuizResponse(
+                quiz.getId(),
+                quiz.getNumber(),
+                quiz.getQuizType(),
+                quiz.getQuestion(),
+                (quiz.getS3Info() != null) ? quiz.getS3Info().getUrl() : null
+        );
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/util/DiscordUtil.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/util/DiscordUtil.java
@@ -1,0 +1,36 @@
+package org.cotato.csquiz.domain.education.util;
+
+import java.awt.Color;
+import java.util.List;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import org.cotato.csquiz.api.quiz.dto.ChoiceResponse;
+import org.cotato.csquiz.domain.education.enums.QuizType;
+import org.cotato.csquiz.domain.education.service.dto.RandomQuizResponse;
+
+public class DiscordUtil {
+
+    public static MessageEmbed getMultipleQuizEmbeds(RandomQuizResponse quiz) {
+        EmbedBuilder eb = new EmbedBuilder();
+        eb.setTitle("오늘의 퀴즈!");
+        eb.setDescription("CS교육에서 풀었던 문제를 복습해봐요:)");
+        eb.setColor(Color.cyan);
+        eb.addField("타입", QuizType.MULTIPLE_QUIZ.getDescription(), false);
+        eb.addField("문제: ", quiz.question(), false);
+
+        eb.setImage(quiz.imageUrl());
+
+        return eb.build();
+    }
+
+    public static List<Button> getButtons(List<ChoiceResponse> choices) {
+        return choices.stream()
+                .map(choice -> Button.primary(String.valueOf(choice.choiceId()), makeContent(choice.number(), choice.content())))
+                .toList();
+    }
+
+    private static String makeContent(Integer choiceNumber, String content) {
+        return choiceNumber + "번: " + content;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,3 +17,11 @@ spring:
 springdoc:
   swagger-ui:
     enabled: false
+
+discord:
+  bot:
+    token: ${DISCORD_BOT_TOKEN}
+  guild:
+    id: ${GUILD_ID}
+  channel:
+    id: ${CHANNEL_ID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,3 +69,13 @@ aes:
 
 location:
   distance: ${STANDARD_DISTANCE}
+
+discord:
+  bot:
+    token: ${TEST_DISCORD_TOKEN}
+
+  guild:
+    id: ${TEST_GUILD_ID}
+
+  channel:
+    id: ${TEST_CHANNEL_ID}


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용

- [x] : jda를 활용한 디스코드 봇 기능 구현
- [x] : 전송한 퀴즈는 7일이내에 재전송 방지 기능 구현


## 🗣 ️리뷰 요구 사항

- Redis로 7일 이내에 전송된 문제는 제외를 했는데 이 부분에 대한 피드백 부탁드립니다.
- Discord bot과 Spring Application의 커넥션이 어플리케이션 시작 ~ 종료로 전체 시점인데 리소스가 괜찮을지에 대한 의견 궁금합니다.