### PR TITLE
[COT-13] Feature: OM 전환 및 가입 승인 시 이메일로 결과 전송

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/email/EmailService.java
+++ b/src/main/java/org/cotato/csquiz/common/email/EmailService.java
@@ -1,0 +1,47 @@
+package org.cotato.csquiz.common.email;
+
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_EMAIL;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_PERSONAL;
+
+import jakarta.mail.Message.RecipientType;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendEmail(String recipient, String messageBody, String subject) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+
+            message.addRecipients(RecipientType.TO, recipient);
+            message.setSubject(subject);
+            message.setText(messageBody, "utf-8", "html");
+            message.setFrom(getInternetAddress());
+            mailSender.send(message);
+            log.info("이메일 전송 완료");
+        } catch (MessagingException e) {
+            throw new AppException(ErrorCode.EMAIL_SEND_ERROR);
+        }
+    }
+
+    private InternetAddress getInternetAddress() {
+        try {
+            return new InternetAddress(SENDER_EMAIL, SENDER_PERSONAL);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -101,6 +101,7 @@ public enum ErrorCode {
     GUILD_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "S-010", "디스코드 서버를 찾지 못했습니다."),
     CHANNEL_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "S-011", "디스코드 채널을 찾지 못했습니다."),
     DISCORD_BUTTON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-012" , "디스코드 버튼 이벤트 ID를 찾지 못했습니다."),
+    EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-013", "이메일 전송에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/cotato/csquiz/common/util/EmailUtil.java
+++ b/src/main/java/org/cotato/csquiz/common/util/EmailUtil.java
@@ -5,6 +5,8 @@ import static org.cotato.csquiz.domain.auth.constant.EmailConstants.COTATO_HYPER
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_GENERATION_PREFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_NAME_SUFFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_POSITION_PREFIX;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MESSAGE_PREFIX;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MESSAGE_SUFFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_FAIL_MESSAGE;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_MESSAGE_PREFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_MESSAGE;
@@ -37,6 +39,13 @@ public class EmailUtil {
                 .append(getMemberName(recipientMember.getName()))
                 .append(SIGNUP_FAIL_MESSAGE)
                 .append(COTATO_HYPERLINK));
+    }
+
+    public static String getVerificationMessageBody(String verificationCode) {
+        StringBuilder sb = new StringBuilder();
+        return String.valueOf(sb.append(MESSAGE_PREFIX)
+                .append(verificationCode)
+                .append(MESSAGE_SUFFIX));
     }
 
     private static String getMemberName(String memberName) {

--- a/src/main/java/org/cotato/csquiz/common/util/EmailUtil.java
+++ b/src/main/java/org/cotato/csquiz/common/util/EmailUtil.java
@@ -1,0 +1,45 @@
+package org.cotato.csquiz.common.util;
+
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_MESSAGE;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.COTATO_HYPERLINK;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_GENERATION_PREFIX;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_NAME_SUFFIX;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_POSITION_PREFIX;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_FAIL_MESSAGE;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_MESSAGE_PREFIX;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_MESSAGE;
+
+import org.cotato.csquiz.domain.auth.entity.Member;
+
+public class EmailUtil {
+
+    public static String createSignupApprovedMessageBody(Member recipientMember) {
+        StringBuilder sb = new StringBuilder();
+        return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
+                .append(getMemberName(recipientMember.getName()))
+                .append(SIGNUP_SUCCESS_MESSAGE)
+                .append(String.format(MEMBER_GENERATION_PREFIX, recipientMember.getPassedGenerationNumber()))
+                .append(String.format(MEMBER_POSITION_PREFIX, recipientMember.getPosition().name()))
+                .append(COTATO_HYPERLINK));
+    }
+
+    public static String createOldMemberConversionEmailBody(Member recipientMember) {
+        StringBuilder sb = new StringBuilder();
+        return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
+                .append(getMemberName(recipientMember.getName()))
+                .append(CONVERSION_TO_OM_MESSAGE)
+                .append(COTATO_HYPERLINK));
+    }
+
+    public static String createSignupRejectionMessageBody(Member recipientMember) {
+        StringBuilder sb = new StringBuilder();
+        return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
+                .append(getMemberName(recipientMember.getName()))
+                .append(SIGNUP_FAIL_MESSAGE)
+                .append(COTATO_HYPERLINK));
+    }
+
+    private static String getMemberName(String memberName) {
+        return String.format(MEMBER_NAME_SUFFIX, memberName);
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
@@ -18,4 +18,13 @@ public class EmailConstants {
             + "<h3 style=\"color: #336699; font-family: 'Arial', sans-serif; font-size: 18px;\">10분 안에 입력 부탁드립니다. 감사합니다!</h3>"
             + "</div>"
             + "</div>";
+    public static final String SIGNUP_SUCCESS_SUBJECT = "코테이토 가입 승인이 완료됐습니다.";
+    public static final String SIGNUP_SUCCESS_MESSAGE = "가입이 승인되었습니다<br>";
+    public static final String SIGNUP_MESSAGE_PREFIX = ""
+            + "<div style=\"background-color: #f2f2f2; padding: 20px;\">"
+            + "<div style=\"background-color: #ffffff; padding: 20px;\">"
+            + "<h1 style=\"color: #336699; font-family: 'Arial', sans-serif; font-size: 24px;\">안녕하세요 IT연합동아리 코테이토 코테이토입니다!</h1>"
+            + "<br>";
+    public static final String COTATO_HYPERLINK = "<br>"
+            + "<a href=\"https://www.cotato.kr\" style=\"display: inline-block; background-color: #336699; color: #ffffff; padding: 10px 20px; font-family: 'Arial', sans-serif; font-size: 16px; text-decoration: none; border-radius: 5px;\">코테이토 방문하기</a>";
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
@@ -22,7 +22,9 @@ public class EmailConstants {
     public static final String MEMBER_POSITION_PREFIX = "포지션: %s" + "<br>";
     public static final String MEMBER_GENERATION_PREFIX = "합격기수: %s" + "기<br>";
     public static final String SIGNUP_SUCCESS_SUBJECT = "코테이토 가입 승인이 완료됐습니다.";
+    public static final String SIGNUP_REJECT_SUBJECT = "코테이토 가입 승인이 거절됐습니다.";
     public static final String SIGNUP_SUCCESS_MESSAGE = "가입이 승인되었습니다<br>";
+    public static final String SIGNUP_FAIL_MESSAGE = "가입이 거절되었습니다<br>";
     public static final String SIGNUP_MESSAGE_PREFIX = ""
             + "<div style=\"background-color: #f2f2f2; padding: 20px;\">"
             + "<div style=\"background-color: #ffffff; padding: 20px;\">"

--- a/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
@@ -18,6 +18,9 @@ public class EmailConstants {
             + "<h3 style=\"color: #336699; font-family: 'Arial', sans-serif; font-size: 18px;\">10분 안에 입력 부탁드립니다. 감사합니다!</h3>"
             + "</div>"
             + "</div>";
+    public static final String MEMBER_NAME_SUFFIX = "%s님의 ";
+    public static final String MEMBER_POSITION_PREFIX = "포지션: %s" + "<br>";
+    public static final String MEMBER_GENERATION_PREFIX = "합격기수: %s" + "기<br>";
     public static final String SIGNUP_SUCCESS_SUBJECT = "코테이토 가입 승인이 완료됐습니다.";
     public static final String SIGNUP_SUCCESS_MESSAGE = "가입이 승인되었습니다<br>";
     public static final String SIGNUP_MESSAGE_PREFIX = ""

--- a/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
@@ -28,7 +28,7 @@ public class EmailConstants {
     public static final String SIGNUP_MESSAGE_PREFIX = ""
             + "<div style=\"background-color: #f2f2f2; padding: 20px;\">"
             + "<div style=\"background-color: #ffffff; padding: 20px;\">"
-            + "<h1 style=\"color: #336699; font-family: 'Arial', sans-serif; font-size: 24px;\">안녕하세요 IT연합동아리 코테이토 코테이토입니다!</h1>"
+            + "<h1 style=\"color: #336699; font-family: 'Arial', sans-serif; font-size: 24px;\">안녕하세요 IT연합동아리 코테이토입니다!</h1>"
             + "<br>";
     public static final String COTATO_HYPERLINK = "<br>"
             + "<a href=\"https://www.cotato.kr\" style=\"display: inline-block; background-color: #336699; color: #ffffff; padding: 10px 20px; font-family: 'Arial', sans-serif; font-size: 16px; text-decoration: none; border-radius: 5px;\">코테이토 방문하기</a>";

--- a/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/constant/EmailConstants.java
@@ -23,8 +23,10 @@ public class EmailConstants {
     public static final String MEMBER_GENERATION_PREFIX = "합격기수: %s" + "기<br>";
     public static final String SIGNUP_SUCCESS_SUBJECT = "코테이토 가입 승인이 완료됐습니다.";
     public static final String SIGNUP_REJECT_SUBJECT = "코테이토 가입 승인이 거절됐습니다.";
+    public static final String CONVERSION_TO_OM_SUBJECT = "코테이토 계정이 OM 전환됐습니다.";
     public static final String SIGNUP_SUCCESS_MESSAGE = "가입이 승인되었습니다<br>";
     public static final String SIGNUP_FAIL_MESSAGE = "가입이 거절되었습니다<br>";
+    public static final String CONVERSION_TO_OM_MESSAGE = "권한이 OM으로 변경되었습니다<br>";
     public static final String SIGNUP_MESSAGE_PREFIX = ""
             + "<div style=\"background-color: #f2f2f2; padding: 20px;\">"
             + "<div style=\"background-color: #ffffff; padding: 20px;\">"

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
@@ -125,6 +125,8 @@ public class AdminService {
             }
             member.updateRole(MemberRole.OLD_MEMBER);
             memberRepository.save(member);
+
+            emailVerificationService.sendConvertToOldMemberToEmail(member);
         }
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
@@ -83,7 +83,7 @@ public class AdminService {
             addRefusedMember(member);
         }
 
-        emailVerificationService.sendSignUpRejectedToEmail(member);
+        emailVerificationService.sendSignupRejectionToEmail(member);
     }
 
     private Member findMember(Long memberId) {
@@ -126,7 +126,7 @@ public class AdminService {
             member.updateRole(MemberRole.OLD_MEMBER);
             memberRepository.save(member);
 
-            emailVerificationService.sendConvertToOldMemberToEmail(member);
+            emailVerificationService.sendOldMemberConversionToEmail(member);
         }
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
@@ -69,6 +69,8 @@ public class AdminService {
             member.updatePosition(request.position());
             deleteRefusedMember(member);
         }
+
+        emailVerificationService.sendSignUpApprovedToEmail(member);
     }
 
     @Transactional

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
@@ -32,6 +32,7 @@ public class AdminService {
     private final GenerationRepository generationRepository;
     private final RefusedMemberRepository refusedMemberRepository;
     private final MemberService memberService;
+    private final EmailVerificationService emailVerificationService;
 
     public List<ApplyMemberInfoResponse> findApplicantList() {
         return createApplyInfoList(memberRepository.findAllByRole(MemberRole.GENERAL));
@@ -53,6 +54,8 @@ public class AdminService {
             member.updatePosition(request.position());
             memberRepository.save(member);
         }
+
+        emailVerificationService.sendSignUpApprovedToEmail(member);
     }
 
     @Transactional

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
@@ -32,7 +32,7 @@ public class AdminService {
     private final GenerationRepository generationRepository;
     private final RefusedMemberRepository refusedMemberRepository;
     private final MemberService memberService;
-    private final EmailVerificationService emailVerificationService;
+    private final EmailNotificationService emailNotificationService;
 
     public List<ApplyMemberInfoResponse> findApplicantList() {
         return createApplyInfoList(memberRepository.findAllByRole(MemberRole.GENERAL));
@@ -55,7 +55,7 @@ public class AdminService {
             memberRepository.save(member);
         }
 
-        emailVerificationService.sendSignUpApprovedToEmail(member);
+        emailNotificationService.sendSignUpApprovedToEmail(member);
     }
 
     @Transactional
@@ -70,7 +70,7 @@ public class AdminService {
             deleteRefusedMember(member);
         }
 
-        emailVerificationService.sendSignUpApprovedToEmail(member);
+        emailNotificationService.sendSignUpApprovedToEmail(member);
     }
 
     @Transactional
@@ -83,7 +83,7 @@ public class AdminService {
             addRefusedMember(member);
         }
 
-        emailVerificationService.sendSignupRejectionToEmail(member);
+        emailNotificationService.sendSignupRejectionToEmail(member);
     }
 
     private Member findMember(Long memberId) {
@@ -126,7 +126,7 @@ public class AdminService {
             member.updateRole(MemberRole.OLD_MEMBER);
             memberRepository.save(member);
 
-            emailVerificationService.sendOldMemberConversionToEmail(member);
+            emailNotificationService.sendOldMemberConversionToEmail(member);
         }
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AdminService.java
@@ -80,6 +80,8 @@ public class AdminService {
             memberRepository.save(member);
             addRefusedMember(member);
         }
+
+        emailVerificationService.sendSignUpRejectedToEmail(member);
     }
 
     private Member findMember(Long memberId) {

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailNotificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailNotificationService.java
@@ -1,0 +1,51 @@
+package org.cotato.csquiz.domain.auth.service;
+
+import static org.cotato.csquiz.common.util.EmailUtil.createOldMemberConversionEmailBody;
+import static org.cotato.csquiz.common.util.EmailUtil.createSignupApprovedMessageBody;
+import static org.cotato.csquiz.common.util.EmailUtil.createSignupRejectionMessageBody;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_SUBJECT;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_REJECT_SUBJECT;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_SUBJECT;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.common.email.EmailService;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.utils.EmailFormValidator;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailNotificationService {
+
+    private final EmailService emailService;
+    private final EmailFormValidator emailFormValidator;
+
+    public void sendSignUpApprovedToEmail(Member recipientMember) {
+        emailFormValidator.validateEmailForm(recipientMember.getEmail());
+
+        String successMessage = createSignupApprovedMessageBody(recipientMember);
+
+        emailService.sendEmail(recipientMember.getEmail(), successMessage, SIGNUP_SUCCESS_SUBJECT);
+        log.info("가입 승인 완료 이메일 전송 완료");
+    }
+
+    public void sendSignupRejectionToEmail(Member recipientMember) {
+        emailFormValidator.validateEmailForm(recipientMember.getEmail());
+
+        String rejectMessage = createSignupRejectionMessageBody(recipientMember);
+
+        emailService.sendEmail(recipientMember.getEmail(), rejectMessage, SIGNUP_REJECT_SUBJECT);
+        log.info("가입 승인 거절 이메일 전송 완료");
+    }
+
+    public void sendOldMemberConversionToEmail(Member recipientMember) {
+        emailFormValidator.validateEmailForm(recipientMember.getEmail());
+
+        String conversionMessageBody = createOldMemberConversionEmailBody(recipientMember);
+
+        emailService.sendEmail(recipientMember.getEmail(), conversionMessageBody, CONVERSION_TO_OM_SUBJECT);
+        log.info("OM 전환 이메일 전송 완료");
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -1,19 +1,14 @@
 package org.cotato.csquiz.domain.auth.service;
 
+import static org.cotato.csquiz.common.util.EmailUtil.createOldMemberConversionEmailBody;
+import static org.cotato.csquiz.common.util.EmailUtil.createSignupApprovedMessageBody;
+import static org.cotato.csquiz.common.util.EmailUtil.createSignupRejectionMessageBody;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_SUBJECT;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_MESSAGE;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.COTATO_HYPERLINK;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_GENERATION_PREFIX;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_NAME_SUFFIX;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_POSITION_PREFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MESSAGE_PREFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MESSAGE_SUFFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_EMAIL;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_PERSONAL;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_FAIL_MESSAGE;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_MESSAGE_PREFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_REJECT_SUBJECT;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_MESSAGE;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_SUBJECT;
 
 import jakarta.mail.Message.RecipientType;
@@ -70,16 +65,6 @@ public class EmailVerificationService {
         log.info("가입 승인 완료 이메일 전송 완료");
     }
 
-    private String createSignupApprovedMessageBody(Member recipientMember) {
-        StringBuilder sb = new StringBuilder();
-        return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
-                .append(getMemberName(recipientMember.getName()))
-                .append(SIGNUP_SUCCESS_MESSAGE)
-                .append(String.format(MEMBER_GENERATION_PREFIX, recipientMember.getPassedGenerationNumber()))
-                .append(String.format(MEMBER_POSITION_PREFIX, recipientMember.getPosition().name()))
-                .append(COTATO_HYPERLINK));
-    }
-
     public void sendSignupRejectionToEmail(Member recipientMember) {
         emailFormValidator.validateEmailForm(recipientMember.getEmail());
 
@@ -89,14 +74,6 @@ public class EmailVerificationService {
         log.info("가입 승인 거절 이메일 전송 완료");
     }
 
-    private String createSignupRejectionMessageBody(Member recipientMember) {
-        StringBuilder sb = new StringBuilder();
-        return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
-                .append(getMemberName(recipientMember.getName()))
-                .append(SIGNUP_FAIL_MESSAGE)
-                .append(COTATO_HYPERLINK));
-    }
-
     public void sendOldMemberConversionToEmail(Member recipientMember) {
         emailFormValidator.validateEmailForm(recipientMember.getEmail());
 
@@ -104,18 +81,6 @@ public class EmailVerificationService {
 
         sendEmail(recipientMember.getEmail(), conversionMessageBody, CONVERSION_TO_OM_SUBJECT);
         log.info("OM 전환 이메일 전송 완료");
-    }
-
-    private String createOldMemberConversionEmailBody(Member recipientMember) {
-        StringBuilder sb = new StringBuilder();
-        return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
-                .append(getMemberName(recipientMember.getName()))
-                .append(CONVERSION_TO_OM_MESSAGE)
-                .append(COTATO_HYPERLINK));
-    }
-
-    private String getMemberName(String memberName) {
-        return String.format(MEMBER_NAME_SUFFIX, memberName);
     }
 
     private String getVerificationCode() {

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -29,7 +29,6 @@ import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.domain.auth.cache.EmailRedisRepository;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.EmailType;
-import org.cotato.csquiz.domain.auth.enums.MemberPosition;
 import org.cotato.csquiz.domain.auth.utils.EmailFormValidator;
 import org.cotato.csquiz.domain.auth.cache.VerificationCodeRedisRepository;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -65,13 +64,13 @@ public class EmailVerificationService {
     public void sendSignUpApprovedToEmail(Member recipientMember) {
         emailFormValidator.validateEmailForm(recipientMember.getEmail());
 
-        String successMessage = getSuccessMessageBody(recipientMember);
+        String successMessage = createSignupApprovedMessageBody(recipientMember);
 
         sendEmail(recipientMember.getEmail(), successMessage, SIGNUP_SUCCESS_SUBJECT);
         log.info("가입 승인 완료 이메일 전송 완료");
     }
 
-    private String getSuccessMessageBody(Member recipientMember) {
+    private String createSignupApprovedMessageBody(Member recipientMember) {
         StringBuilder sb = new StringBuilder();
         return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
                 .append(getMemberName(recipientMember.getName()))
@@ -81,16 +80,16 @@ public class EmailVerificationService {
                 .append(COTATO_HYPERLINK));
     }
 
-    public void sendSignUpRejectedToEmail(Member recipientMember) {
+    public void sendSignupRejectionToEmail(Member recipientMember) {
         emailFormValidator.validateEmailForm(recipientMember.getEmail());
 
-        String rejectMessage = getRejectMessageBody(recipientMember);
+        String rejectMessage = createSignupRejectionMessageBody(recipientMember);
 
         sendEmail(recipientMember.getEmail(), rejectMessage, SIGNUP_REJECT_SUBJECT);
         log.info("가입 승인 거절 이메일 전송 완료");
     }
 
-    private String getRejectMessageBody(Member recipientMember) {
+    private String createSignupRejectionMessageBody(Member recipientMember) {
         StringBuilder sb = new StringBuilder();
         return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
                 .append(getMemberName(recipientMember.getName()))
@@ -98,16 +97,16 @@ public class EmailVerificationService {
                 .append(COTATO_HYPERLINK));
     }
 
-    public void sendConvertToOldMemberToEmail(Member recipientMember) {
+    public void sendOldMemberConversionToEmail(Member recipientMember) {
         emailFormValidator.validateEmailForm(recipientMember.getEmail());
 
-        String conversionMessageBody = getConvertToOldMemberMessageBody(recipientMember);
+        String conversionMessageBody = createOldMemberConversionEmailBody(recipientMember);
 
         sendEmail(recipientMember.getEmail(), conversionMessageBody, CONVERSION_TO_OM_SUBJECT);
         log.info("OM 전환 이메일 전송 완료");
     }
 
-    private String getConvertToOldMemberMessageBody(Member recipientMember) {
+    private String createOldMemberConversionEmailBody(Member recipientMember) {
         StringBuilder sb = new StringBuilder();
         return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
                 .append(getMemberName(recipientMember.getName()))

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -5,19 +5,13 @@ import static org.cotato.csquiz.common.util.EmailUtil.createSignupApprovedMessag
 import static org.cotato.csquiz.common.util.EmailUtil.createSignupRejectionMessageBody;
 import static org.cotato.csquiz.common.util.EmailUtil.getVerificationMessageBody;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_SUBJECT;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_EMAIL;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_PERSONAL;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_REJECT_SUBJECT;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_SUBJECT;
 
-import jakarta.mail.Message.RecipientType;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.InternetAddress;
-import jakarta.mail.internet.MimeMessage;
-import java.io.UnsupportedEncodingException;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.common.email.EmailService;
 import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.domain.auth.cache.EmailRedisRepository;
@@ -25,7 +19,6 @@ import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.EmailType;
 import org.cotato.csquiz.domain.auth.utils.EmailFormValidator;
 import org.cotato.csquiz.domain.auth.cache.VerificationCodeRedisRepository;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +31,7 @@ public class EmailVerificationService {
     private static final int CODE_LENGTH = 6;
     private static final int CODE_BOUNDARY = 10;
 
-    private final JavaMailSender mailSender;
+    private final EmailService emailService;
     private final VerificationCodeRedisRepository verificationCodeRedisRepository;
     private final EmailFormValidator emailFormValidator;
     private final EmailRedisRepository emailRedisRepository;
@@ -54,7 +47,7 @@ public class EmailVerificationService {
 
         String verificationMessage = getVerificationMessageBody(verificationCode);
 
-        sendEmail(recipient, verificationMessage, subject);
+        emailService.sendEmail(recipient, verificationMessage, subject);
     }
 
     public void sendSignUpApprovedToEmail(Member recipientMember) {
@@ -62,7 +55,7 @@ public class EmailVerificationService {
 
         String successMessage = createSignupApprovedMessageBody(recipientMember);
 
-        sendEmail(recipientMember.getEmail(), successMessage, SIGNUP_SUCCESS_SUBJECT);
+        emailService.sendEmail(recipientMember.getEmail(), successMessage, SIGNUP_SUCCESS_SUBJECT);
         log.info("가입 승인 완료 이메일 전송 완료");
     }
 
@@ -71,7 +64,7 @@ public class EmailVerificationService {
 
         String rejectMessage = createSignupRejectionMessageBody(recipientMember);
 
-        sendEmail(recipientMember.getEmail(), rejectMessage, SIGNUP_REJECT_SUBJECT);
+        emailService.sendEmail(recipientMember.getEmail(), rejectMessage, SIGNUP_REJECT_SUBJECT);
         log.info("가입 승인 거절 이메일 전송 완료");
     }
 
@@ -80,7 +73,7 @@ public class EmailVerificationService {
 
         String conversionMessageBody = createOldMemberConversionEmailBody(recipientMember);
 
-        sendEmail(recipientMember.getEmail(), conversionMessageBody, CONVERSION_TO_OM_SUBJECT);
+        emailService.sendEmail(recipientMember.getEmail(), conversionMessageBody, CONVERSION_TO_OM_SUBJECT);
         log.info("OM 전환 이메일 전송 완료");
     }
 
@@ -93,28 +86,6 @@ public class EmailVerificationService {
         return String.valueOf(builder);
     }
 
-    private void sendEmail(String recipient, String messageBody, String subject) {
-        try {
-            MimeMessage message = mailSender.createMimeMessage();
-
-            message.addRecipients(RecipientType.TO, recipient);
-            message.setSubject(subject);
-            message.setText(messageBody, "utf-8", "html");
-            message.setFrom(getInternetAddress());
-            mailSender.send(message);
-            log.info("이메일 전송 완료");
-        } catch (MessagingException e) {
-            throw new AppException(ErrorCode.EMAIL_SEND_ERROR);
-        }
-    }
-
-    private InternetAddress getInternetAddress() {
-        try {
-            return new InternetAddress(SENDER_EMAIL, SENDER_PERSONAL);
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     public void verifyCode(EmailType type, String email, String code) {
         String savedVerificationCode = verificationCodeRedisRepository.getByEmail(type, email);

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -64,9 +64,9 @@ public class EmailVerificationService {
         emailFormValidator.validateEmailForm(recipientMember.getEmail());
 
         String successMessage = getSuccessMessageBody(recipientMember);
-        log.info("가입 승인 완료 이메일 전송 완료");
 
         sendEmail(recipientMember.getEmail(), successMessage, SIGNUP_SUCCESS_SUBJECT);
+        log.info("가입 승인 완료 이메일 전송 완료");
     }
 
     private String getSuccessMessageBody(Member recipientMember) {
@@ -82,9 +82,9 @@ public class EmailVerificationService {
         emailFormValidator.validateEmailForm(recipientMember.getEmail());
 
         String rejectMessage = getRejectMessageBody(recipientMember);
-        log.info("가입 승인 거절 이메일 전송 완료");
 
         sendEmail(recipientMember.getEmail(), rejectMessage, SIGNUP_REJECT_SUBJECT);
+        log.info("가입 승인 거절 이메일 전송 완료");
     }
 
     private String getRejectMessageBody(Member recipientMember) {

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -3,9 +3,8 @@ package org.cotato.csquiz.domain.auth.service;
 import static org.cotato.csquiz.common.util.EmailUtil.createOldMemberConversionEmailBody;
 import static org.cotato.csquiz.common.util.EmailUtil.createSignupApprovedMessageBody;
 import static org.cotato.csquiz.common.util.EmailUtil.createSignupRejectionMessageBody;
+import static org.cotato.csquiz.common.util.EmailUtil.getVerificationMessageBody;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_SUBJECT;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MESSAGE_PREFIX;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MESSAGE_SUFFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_EMAIL;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_PERSONAL;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_REJECT_SUBJECT;
@@ -113,20 +112,13 @@ public class EmailVerificationService {
 
             message.addRecipients(RecipientType.TO, recipient);
             message.setSubject(subject);
-            message.setText(getVerificationText(verificationCode), "utf-8", "html");
+            message.setText(getVerificationMessageBody(verificationCode), "utf-8", "html");
             message.setFrom(getInternetAddress());
             mailSender.send(message);
             log.info("이메일 전송 완료");
         } catch (MessagingException e) {
             throw new AppException(ErrorCode.EMAIL_SEND_ERROR);
         }
-    }
-
-    private String getVerificationText(String verificationCode) {
-        StringBuilder sb = new StringBuilder();
-        return String.valueOf(sb.append(MESSAGE_PREFIX)
-                .append(verificationCode)
-                .append(MESSAGE_SUFFIX));
     }
 
     private InternetAddress getInternetAddress() {

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -76,7 +76,8 @@ public class EmailVerificationService {
         return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
                 .append(getMemberName(recipientMember.getName()))
                 .append(SIGNUP_SUCCESS_MESSAGE)
-                .append(getMemberInfo(recipientMember.getPassedGenerationNumber(), recipientMember.getPosition()))
+                .append(String.format(MEMBER_GENERATION_PREFIX, recipientMember.getPassedGenerationNumber()))
+                .append(String.format(MEMBER_POSITION_PREFIX, recipientMember.getPosition().name()))
                 .append(COTATO_HYPERLINK));
     }
 
@@ -95,13 +96,6 @@ public class EmailVerificationService {
                 .append(getMemberName(recipientMember.getName()))
                 .append(SIGNUP_FAIL_MESSAGE)
                 .append(COTATO_HYPERLINK));
-    }
-
-    private String getMemberInfo(Integer passedGenerationNumber, MemberPosition position) {
-        StringBuilder sb = new StringBuilder();
-        return String.valueOf(
-                sb.append(String.format(MEMBER_GENERATION_PREFIX, passedGenerationNumber))
-                        .append(String.format(MEMBER_POSITION_PREFIX, position.name())));
     }
 
     public void sendConvertToOldMemberToEmail(Member recipientMember) {

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -145,7 +145,7 @@ public class EmailVerificationService {
             mailSender.send(message);
             log.info("이메일 전송 완료");
         } catch (MessagingException e) {
-            throw new RuntimeException(e);
+            throw new AppException(ErrorCode.EMAIL_SEND_ERROR);
         }
     }
 
@@ -160,7 +160,7 @@ public class EmailVerificationService {
             mailSender.send(message);
             log.info("이메일 전송 완료");
         } catch (MessagingException e) {
-            throw new RuntimeException(e);
+            throw new AppException(ErrorCode.EMAIL_SEND_ERROR);
         }
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -1,5 +1,7 @@
 package org.cotato.csquiz.domain.auth.service;
 
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_SUBJECT;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_MESSAGE;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.COTATO_HYPERLINK;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_GENERATION_PREFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MEMBER_NAME_SUFFIX;
@@ -100,6 +102,23 @@ public class EmailVerificationService {
         return String.valueOf(
                 sb.append(String.format(MEMBER_GENERATION_PREFIX, passedGenerationNumber))
                         .append(String.format(MEMBER_POSITION_PREFIX, position.name())));
+    }
+
+    public void sendConvertToOldMemberToEmail(Member recipientMember) {
+        emailFormValidator.validateEmailForm(recipientMember.getEmail());
+
+        String conversionMessageBody = getConvertToOldMemberMessageBody(recipientMember);
+
+        sendEmail(recipientMember.getEmail(), conversionMessageBody, CONVERSION_TO_OM_SUBJECT);
+        log.info("OM 전환 이메일 전송 완료");
+    }
+
+    private String getConvertToOldMemberMessageBody(Member recipientMember) {
+        StringBuilder sb = new StringBuilder();
+        return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
+                .append(getMemberName(recipientMember.getName()))
+                .append(CONVERSION_TO_OM_MESSAGE)
+                .append(COTATO_HYPERLINK));
     }
 
     private String getMemberName(String memberName) {

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -8,7 +8,9 @@ import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MESSAGE_PREF
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.MESSAGE_SUFFIX;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_EMAIL;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SENDER_PERSONAL;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_FAIL_MESSAGE;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_MESSAGE_PREFIX;
+import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_REJECT_SUBJECT;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_MESSAGE;
 import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_SUBJECT;
 
@@ -73,6 +75,23 @@ public class EmailVerificationService {
                 .append(getMemberName(recipientMember.getName()))
                 .append(SIGNUP_SUCCESS_MESSAGE)
                 .append(getMemberInfo(recipientMember.getPassedGenerationNumber(), recipientMember.getPosition()))
+                .append(COTATO_HYPERLINK));
+    }
+
+    public void sendSignUpRejectedToEmail(Member recipientMember) {
+        emailFormValidator.validateEmailForm(recipientMember.getEmail());
+
+        String rejectMessage = getRejectMessageBody(recipientMember);
+        log.info("가입 승인 거절 이메일 전송 완료");
+
+        sendEmail(recipientMember.getEmail(), rejectMessage, SIGNUP_REJECT_SUBJECT);
+    }
+
+    private String getRejectMessageBody(Member recipientMember) {
+        StringBuilder sb = new StringBuilder();
+        return String.valueOf(sb.append(SIGNUP_MESSAGE_PREFIX)
+                .append(getMemberName(recipientMember.getName()))
+                .append(SIGNUP_FAIL_MESSAGE)
                 .append(COTATO_HYPERLINK));
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -52,7 +52,9 @@ public class EmailVerificationService {
         emailRedisRepository.saveEmail(type, recipient);
         verificationCodeRedisRepository.saveCodeWithEmail(type, recipient, verificationCode);
 
-        sendEmailWithVerificationCode(recipient, verificationCode, subject);
+        String verificationMessage = getVerificationMessageBody(verificationCode);
+
+        sendEmail(recipient, verificationMessage, subject);
     }
 
     public void sendSignUpApprovedToEmail(Member recipientMember) {
@@ -98,21 +100,6 @@ public class EmailVerificationService {
             message.addRecipients(RecipientType.TO, recipient);
             message.setSubject(subject);
             message.setText(messageBody, "utf-8", "html");
-            message.setFrom(getInternetAddress());
-            mailSender.send(message);
-            log.info("이메일 전송 완료");
-        } catch (MessagingException e) {
-            throw new AppException(ErrorCode.EMAIL_SEND_ERROR);
-        }
-    }
-
-    private void sendEmailWithVerificationCode(String recipient, String verificationCode, String subject) {
-        try {
-            MimeMessage message = mailSender.createMimeMessage();
-
-            message.addRecipients(RecipientType.TO, recipient);
-            message.setSubject(subject);
-            message.setText(getVerificationMessageBody(verificationCode), "utf-8", "html");
             message.setFrom(getInternetAddress());
             mailSender.send(message);
             log.info("이메일 전송 완료");

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/EmailVerificationService.java
@@ -1,12 +1,6 @@
 package org.cotato.csquiz.domain.auth.service;
 
-import static org.cotato.csquiz.common.util.EmailUtil.createOldMemberConversionEmailBody;
-import static org.cotato.csquiz.common.util.EmailUtil.createSignupApprovedMessageBody;
-import static org.cotato.csquiz.common.util.EmailUtil.createSignupRejectionMessageBody;
 import static org.cotato.csquiz.common.util.EmailUtil.getVerificationMessageBody;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.CONVERSION_TO_OM_SUBJECT;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_REJECT_SUBJECT;
-import static org.cotato.csquiz.domain.auth.constant.EmailConstants.SIGNUP_SUCCESS_SUBJECT;
 
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +9,6 @@ import org.cotato.csquiz.common.email.EmailService;
 import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.domain.auth.cache.EmailRedisRepository;
-import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.EmailType;
 import org.cotato.csquiz.domain.auth.utils.EmailFormValidator;
 import org.cotato.csquiz.domain.auth.cache.VerificationCodeRedisRepository;
@@ -50,33 +43,6 @@ public class EmailVerificationService {
         emailService.sendEmail(recipient, verificationMessage, subject);
     }
 
-    public void sendSignUpApprovedToEmail(Member recipientMember) {
-        emailFormValidator.validateEmailForm(recipientMember.getEmail());
-
-        String successMessage = createSignupApprovedMessageBody(recipientMember);
-
-        emailService.sendEmail(recipientMember.getEmail(), successMessage, SIGNUP_SUCCESS_SUBJECT);
-        log.info("가입 승인 완료 이메일 전송 완료");
-    }
-
-    public void sendSignupRejectionToEmail(Member recipientMember) {
-        emailFormValidator.validateEmailForm(recipientMember.getEmail());
-
-        String rejectMessage = createSignupRejectionMessageBody(recipientMember);
-
-        emailService.sendEmail(recipientMember.getEmail(), rejectMessage, SIGNUP_REJECT_SUBJECT);
-        log.info("가입 승인 거절 이메일 전송 완료");
-    }
-
-    public void sendOldMemberConversionToEmail(Member recipientMember) {
-        emailFormValidator.validateEmailForm(recipientMember.getEmail());
-
-        String conversionMessageBody = createOldMemberConversionEmailBody(recipientMember);
-
-        emailService.sendEmail(recipientMember.getEmail(), conversionMessageBody, CONVERSION_TO_OM_SUBJECT);
-        log.info("OM 전환 이메일 전송 완료");
-    }
-
     private String getVerificationCode() {
         final ThreadLocalRandom random = ThreadLocalRandom.current();
         StringBuilder builder = new StringBuilder();
@@ -85,7 +51,6 @@ public class EmailVerificationService {
         }
         return String.valueOf(builder);
     }
-
 
     public void verifyCode(EmailType type, String email, String code) {
         String savedVerificationCode = verificationCodeRedisRepository.getByEmail(type, email);


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용
- 승인 완료, 거부, 재승인 시 이메일 전송
- OM 전환 시 이메일 전송

## 🗣 ️리뷰 요구 사항
- OM 전환 시 List로 memberId를 받는데 받은 멤버 중 하나의 계정에서 문제가 생겨도 다 전환이 안되는 문제가 있을 것 같다.