### PR TITLE
 [COT-15] Refactor: 멤버 프로필 이미지 변경, 삭제 시 인증 방식 변경 

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -49,7 +49,7 @@ public class MemberController {
     @Operation(summary = "멤버 전화번호 수정 API")
     @PatchMapping("/phone-number")
     public ResponseEntity<Void> updatePhoneNumber(@AuthenticationPrincipal Long memberId,
-            @RequestBody @Valid UpdatePhoneNumberRequest request) {
+                                                  @RequestBody @Valid UpdatePhoneNumberRequest request) {
         memberService.updatePhoneNumber(memberId, request.phoneNumber());
         return ResponseEntity.noContent().build();
     }
@@ -57,19 +57,17 @@ public class MemberController {
     @Operation(summary = "멤버 프로필 사진 수정 API")
     @PatchMapping(value = "/profile-image", consumes = "multipart/form-data")
     public ResponseEntity<Void> updateProfileImage(
-            @RequestHeader("Authorization") String authorizationHeader,
+            @AuthenticationPrincipal Long memberId,
             @ModelAttribute @Valid UpdateProfileImageRequest request) throws ImageException {
-        String accessToken = jwtTokenProvider.getBearer(authorizationHeader);
-        memberService.updateMemberProfileImage(accessToken, request.image());
+        memberService.updateMemberProfileImage(memberId, request.image());
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "멤버 프로필 사진 삭제 API")
     @DeleteMapping("/profile-image")
     public ResponseEntity<Void> deleteProfileImage(
-            @RequestHeader("Authorization") String authorizationHeader) {
-        String accessToken = jwtTokenProvider.getBearer(authorizationHeader);
-        memberService.deleteMemberProfileImage(accessToken);
+            @AuthenticationPrincipal Long memberId) {
+        memberService.deleteMemberProfileImage(memberId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -79,12 +79,11 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateMemberProfileImage(String accessToken, MultipartFile image) throws ImageException {
+    public void updateMemberProfileImage(Long memberId, MultipartFile image) throws ImageException {
         if (image.isEmpty()) {
             throw new AppException(ErrorCode.FILE_IS_EMPTY);
         }
 
-        Long memberId = jwtTokenProvider.getMemberId(accessToken);
         Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
 
@@ -97,8 +96,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void deleteMemberProfileImage(String accessToken) {
-        Long memberId = jwtTokenProvider.getMemberId(accessToken);
+    public void deleteMemberProfileImage(Long memberId) {
         Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
 


### PR DESCRIPTION
변경 이유: 기존에는 인증 시 헤더에 토큰을 넣고 memberId를 찾는 방식인데 `@AuthenticationPrincipal` 를 통해 간단하게 인증할 수 있는 방법을 찾음

## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용
- 헤더에 토큰을 넣는 방식에서 어노테이션으로 변경
## 🗣 ️리뷰 요구 사항