### PR TITLE
[COT-47] Feature: 관리자 출결 기록 단건 조회 응답 필드 변경

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
@@ -14,6 +14,7 @@ import org.cotato.csquiz.api.attendance.dto.AttendancesResponse;
 import org.cotato.csquiz.api.attendance.dto.MemberAttendanceRecordsResponse;
 import org.cotato.csquiz.api.attendance.dto.OfflineAttendanceRequest;
 import org.cotato.csquiz.api.attendance.dto.OnlineAttendanceRequest;
+import org.cotato.csquiz.api.attendance.dto.SingleAttendanceRecordResponse;
 import org.cotato.csquiz.api.attendance.dto.UpdateAttendanceRecordRequest;
 import org.cotato.csquiz.api.attendance.dto.UpdateAttendanceRequest;
 import org.cotato.csquiz.domain.attendance.service.AttendanceAdminService;
@@ -67,7 +68,7 @@ public class AttendanceController {
 
     @Operation(summary = "회원 출결사항 출석 단위 조회 API")
     @GetMapping("/{attendance-id}/records")
-    public ResponseEntity<List<AttendanceRecordResponse>> findAttendanceRecordsByAttendance(
+    public ResponseEntity<List<SingleAttendanceRecordResponse>> findAttendanceRecordsByAttendance(
             @PathVariable("attendance-id") Long attendanceId) {
         return ResponseEntity.ok().body(attendanceAdminService.findAttendanceRecordsByAttendance(attendanceId));
     }

--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
@@ -8,7 +8,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.api.attendance.dto.AttendResponse;
-import org.cotato.csquiz.api.attendance.dto.AttendanceRecordResponse;
+import org.cotato.csquiz.api.attendance.dto.AttendanceRecordStatisticResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendanceTimeResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendancesResponse;
 import org.cotato.csquiz.api.attendance.dto.MemberAttendanceRecordsResponse;
@@ -59,7 +59,7 @@ public class AttendanceController {
 
     @Operation(summary = "회원 출결사항 기수 단위 조회 API")
     @GetMapping("/records")
-    public ResponseEntity<List<AttendanceRecordResponse>> findAttendanceRecords(
+    public ResponseEntity<List<AttendanceRecordStatisticResponse>> findAttendanceRecords(
             @RequestParam(name = "generationId") Long generationId
     ) {
         return ResponseEntity.ok().body(attendanceAdminService.findAttendanceRecords(generationId));

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceMemberInfo.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceMemberInfo.java
@@ -1,0 +1,18 @@
+package org.cotato.csquiz.api.attendance.dto;
+
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.enums.MemberPosition;
+
+public record AttendanceMemberInfo(
+        Long memberId,
+        String name,
+        MemberPosition position
+) {
+    public static AttendanceMemberInfo from(Member member) {
+        return new AttendanceMemberInfo(
+                member.getId(),
+                member.getName(),
+                member.getPosition()
+        );
+    }
+}

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceRecordResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceRecordResponse.java
@@ -1,7 +1,6 @@
 package org.cotato.csquiz.api.attendance.dto;
 
 import org.cotato.csquiz.domain.auth.entity.Member;
-import org.cotato.csquiz.domain.auth.enums.MemberPosition;
 
 
 public record AttendanceRecordResponse(
@@ -13,19 +12,5 @@ public record AttendanceRecordResponse(
                 AttendanceMemberInfo.from(member),
                 attendanceStatistic
         );
-    }
-
-    public record AttendanceMemberInfo(
-            Long memberId,
-            String name,
-            MemberPosition position
-    ){
-        static AttendanceMemberInfo from(Member member) {
-            return new AttendanceMemberInfo(
-                    member.getId(),
-                    member.getName(),
-                    member.getPosition()
-            );
-        }
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceRecordStatisticResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceRecordStatisticResponse.java
@@ -3,12 +3,12 @@ package org.cotato.csquiz.api.attendance.dto;
 import org.cotato.csquiz.domain.auth.entity.Member;
 
 
-public record AttendanceRecordResponse(
+public record AttendanceRecordStatisticResponse(
         AttendanceMemberInfo memberInfo,
         AttendanceStatistic statistic
 ) {
-    public static AttendanceRecordResponse of(Member member, AttendanceStatistic attendanceStatistic) {
-        return new AttendanceRecordResponse(
+    public static AttendanceRecordStatisticResponse of(Member member, AttendanceStatistic attendanceStatistic) {
+        return new AttendanceRecordStatisticResponse(
                 AttendanceMemberInfo.from(member),
                 attendanceStatistic
         );

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/SingleAttendanceRecordResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/SingleAttendanceRecordResponse.java
@@ -1,13 +1,13 @@
 package org.cotato.csquiz.api.attendance.dto;
 
-import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
+import org.cotato.csquiz.domain.attendance.enums.AttendanceRecordResult;
 import org.cotato.csquiz.domain.auth.entity.Member;
 
 public record SingleAttendanceRecordResponse(
         AttendanceMemberInfo memberInfo,
-        AttendanceResult result
+        AttendanceRecordResult result
 ) {
-    public static SingleAttendanceRecordResponse of(Member member, AttendanceResult result) {
+    public static SingleAttendanceRecordResponse of(Member member, AttendanceRecordResult result) {
         return new SingleAttendanceRecordResponse(
                 AttendanceMemberInfo.from(member),
                 result

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/SingleAttendanceRecordResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/SingleAttendanceRecordResponse.java
@@ -1,0 +1,16 @@
+package org.cotato.csquiz.api.attendance.dto;
+
+import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
+import org.cotato.csquiz.domain.auth.entity.Member;
+
+public record SingleAttendanceRecordResponse(
+        AttendanceMemberInfo memberInfo,
+        AttendanceResult result
+) {
+    public static SingleAttendanceRecordResponse of(Member member, AttendanceResult result) {
+        return new SingleAttendanceRecordResponse(
+                AttendanceMemberInfo.from(member),
+                result
+        );
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/attendance/enums/AttendanceRecordResult.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/enums/AttendanceRecordResult.java
@@ -13,4 +13,18 @@ public enum AttendanceRecordResult {
     ;
 
     private final String description;
+
+    //AttendanceRecord의 출석정보가 AttendanceRecordResult로 바뀌면 로직 수정 TODO
+    public static AttendanceRecordResult convertWithTypeAndResult(AttendanceType type, AttendanceResult result) {
+        if (result == AttendanceResult.ABSENT) {
+            return AttendanceRecordResult.ABSENT;
+        }
+        if (result == AttendanceResult.LATE) {
+            return AttendanceRecordResult.LATE;
+        }
+        if (type == AttendanceType.ONLINE) {
+            return AttendanceRecordResult.ONLINE;
+        }
+        return AttendanceRecordResult.OFFLINE;
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceAdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceAdminService.java
@@ -8,7 +8,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.api.attendance.dto.AttendanceDeadLineDto;
-import org.cotato.csquiz.api.attendance.dto.AttendanceRecordResponse;
+import org.cotato.csquiz.api.attendance.dto.AttendanceRecordStatisticResponse;
+import org.cotato.csquiz.api.attendance.dto.SingleAttendanceRecordResponse;
 import org.cotato.csquiz.api.attendance.dto.UpdateAttendanceRequest;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
@@ -92,7 +93,7 @@ public class AttendanceAdminService {
         attendanceRecordRepository.save(memberAttendanceRecord);
     }
 
-    public List<AttendanceRecordResponse> findAttendanceRecords(Long generationId) {
+    public List<AttendanceRecordStatisticResponse> findAttendanceRecords(Long generationId) {
         List<Long> sessionIds = sessionRepository.findAllByGenerationId(generationId).stream().map(Session::getId).toList();
         List<Attendance> attendances = attendanceRepository.findAllBySessionIdsInQuery(sessionIds);
         Generation generation = generationReader.findById(generationId);
@@ -100,7 +101,7 @@ public class AttendanceAdminService {
         return attendanceRecordService.generateAttendanceResponses(attendances, generation);
     }
 
-    public List<AttendanceRecordResponse> findAttendanceRecordsByAttendance(Long attendanceId) {
+    public List<SingleAttendanceRecordResponse> findAttendanceRecordsByAttendance(Long attendanceId) {
         Attendance attendance = attendanceRepository.findById(attendanceId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 출석이 존재하지 않습니다"));
         Session session = sessionRepository.findById(attendance.getSessionId())

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceAdminService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceAdminService.java
@@ -107,6 +107,6 @@ public class AttendanceAdminService {
         Session session = sessionRepository.findById(attendance.getSessionId())
                 .orElseThrow(() -> new EntityNotFoundException("해당 세션을 찾을 수 없습니다."));
 
-        return attendanceRecordService.generateAttendanceResponses(List.of(attendance), session.getGeneration());
+        return attendanceRecordService.generateSingleAttendanceResponses(attendance, session.getGeneration());
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordService.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.api.attendance.dto.AttendResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendanceParams;
-import org.cotato.csquiz.api.attendance.dto.AttendanceRecordResponse;
+import org.cotato.csquiz.api.attendance.dto.AttendanceRecordStatisticResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendanceStatistic;
 import org.cotato.csquiz.api.attendance.dto.MemberAttendResponse;
 import org.cotato.csquiz.api.attendance.dto.MemberAttendanceRecordsResponse;
@@ -48,7 +48,7 @@ public class AttendanceRecordService {
     private final MemberReader memberReader;
 
 
-    public List<AttendanceRecordResponse> generateAttendanceResponses(List<Attendance> attendances, Generation generation) {
+    public List<AttendanceRecordStatisticResponse> generateAttendanceResponses(List<Attendance> attendances, Generation generation) {
         List<Long> attendanceIds = attendances.stream().map(Attendance::getId).toList();
 
         Map<Long, List<AttendanceRecord>> recordsByMemberId = attendanceRecordRepository.findAllByAttendanceIdsInQuery(attendanceIds).stream()
@@ -56,7 +56,7 @@ public class AttendanceRecordService {
 
         return memberReader.findAllGenerationMember(generation).stream()
                 .sorted(Comparator.comparing(Member::getName))
-                .map(member -> AttendanceRecordResponse.of(
+                .map(member -> AttendanceRecordStatisticResponse.of(
                         member,
                         AttendanceStatistic.of(recordsByMemberId.getOrDefault(member.getId(), List.of()),
                                 attendances.size()

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordService.java
@@ -18,12 +18,15 @@ import org.cotato.csquiz.api.attendance.dto.AttendanceRecordStatisticResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendanceStatistic;
 import org.cotato.csquiz.api.attendance.dto.MemberAttendResponse;
 import org.cotato.csquiz.api.attendance.dto.MemberAttendanceRecordsResponse;
+import org.cotato.csquiz.api.attendance.dto.SingleAttendanceRecordResponse;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.domain.attendance.entity.Attendance;
 import org.cotato.csquiz.domain.attendance.entity.AttendanceRecord;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceOpenStatus;
+import org.cotato.csquiz.domain.attendance.enums.AttendanceRecordResult;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
+import org.cotato.csquiz.domain.attendance.enums.AttendanceType;
 import org.cotato.csquiz.domain.attendance.repository.AttendanceRecordRepository;
 import org.cotato.csquiz.domain.attendance.repository.AttendanceRepository;
 import org.cotato.csquiz.domain.attendance.util.AttendanceUtil;
@@ -63,6 +66,34 @@ public class AttendanceRecordService {
                         )
                 ))
                 .toList();
+    }
+
+    public List<SingleAttendanceRecordResponse> generateSingleAttendanceResponses(Attendance attendance,
+                                                                                  Generation generation) {
+        Map<Long, AttendanceRecord> recordByMemberId = attendanceRecordRepository.findAllByAttendanceId(
+                        attendance.getId())
+                .stream()
+                .collect(Collectors.toMap(
+                        AttendanceRecord::getMemberId,
+                        Function.identity()
+                ));
+        return memberReader.findAllGenerationMember(generation).stream()
+                .sorted(Comparator.comparing(Member::getName))
+                .map(member -> SingleAttendanceRecordResponse.of(
+                        member,
+                        attendanceRecordToRecordResult(recordByMemberId.getOrDefault(member.getId(), null))
+                ))
+                .toList();
+    }
+
+    //AttendanceRecord의 출석정보가 AttendanceRecordResult로 바뀌면 로직 수정 TODO
+    private AttendanceRecordResult attendanceRecordToRecordResult(AttendanceRecord record) {
+        if (record == null){
+            return AttendanceRecordResult.ABSENT;
+        }
+        return AttendanceRecordResult.convertWithTypeAndResult(
+                record.getAttendanceType(),
+                record.getAttendanceResult());
     }
 
     @Transactional


### PR DESCRIPTION
## 연관된 이슈
기존에 출결 기록을 단건 조회할 때 다음과 같이 DTO를 설계했다.
<img width="466" alt="사진" src="https://github.com/user-attachments/assets/9e5bf9ac-b8c9-461e-8ee3-5a1886520e65">

이는 기존에 사용하고 있던 기수별 총 출석 통계를 재사용하기 위함이다.
하지만 이는 결과를 하나의 필드로 표현할 수 있는 방식을 4번의 필드로 표현하기 때문에 어색하다

따라서 하나의 결과값으로 출결 기록을 표현하고자 했다.

```
기존
[
  {
    "memberInfo": {
      "memberId": 1,
      "name": "남기훈",
      "position": "BE"
    },
    "statistic": {
      "online": 1,
      "offline": 0,
      "late": 0,
      "absent": 0
    }
  }
]

수정
[
  {
    "memberInfo": {
      "memberId": 0,
      "name": "string",
      "position": "NONE"
    },
    "result" : OFFLINE //출석정보 OFFLINE, ONLINE, LATE, ABSENT 중 하나
  }
]

```


결과
```

```

이슈링크(url): 


## ✅ 작업 내용
inner class였던 출결 기록 memberInfo를 단독 record로 리팩토링
단건 출석 기록 조회 메소드 개발

기수별 출석 조회 시 결석 횟수 계산이 안되는 문제 해결

## 🗣 ️리뷰 요구 사항