### PR TITLE
[COT-48] Fix: 관리자 기수별 출결 기록 조회 시 결석 정보 카운팅 문제 해결

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceStatistic.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceStatistic.java
@@ -29,7 +29,13 @@ public record AttendanceStatistic(
                 onlineCount,
                 offLineCount,
                 countByStatus.getOrDefault(AttendanceResult.LATE, List.of()).size(),
-                totalAttendance - attendanceRecords.size()
+                totalAttendance - filterNotAbsentRecord(attendanceRecords).size()
         );
+    }
+
+    private static List<AttendanceRecord> filterNotAbsentRecord(List<AttendanceRecord> attendanceRecords) {
+        return attendanceRecords.stream()
+                .filter(AttendanceRecord::isAttendanceResultNotAbsent)
+                .toList();
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/entity/AttendanceRecord.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/entity/AttendanceRecord.java
@@ -128,4 +128,8 @@ public class AttendanceRecord extends BaseTimeEntity {
                 updateAttendanceResult(AttendanceResult.LATE);
         }
     }
+
+    public boolean isAttendanceResultNotAbsent() {
+        return attendanceResult != AttendanceResult.ABSENT;
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용
결석 정보 카운팅 문제 해결

## 🗣 ️리뷰 요구 사항