### PR TITLE
[COT-88] Refactor: 출결 API 필드명 통일

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
@@ -1,36 +1,28 @@
 package org.cotato.csquiz.api.attendance.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.cotato.csquiz.api.attendance.dto.AttendResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendanceRecordResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendanceResponse;
-import org.cotato.csquiz.api.attendance.dto.GenerationMemberAttendanceRecordResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendanceTimeResponse;
 import org.cotato.csquiz.api.attendance.dto.AttendancesResponse;
-import org.cotato.csquiz.api.attendance.dto.MemberAttendanceRecordsResponse;
-import org.cotato.csquiz.api.attendance.dto.OfflineAttendanceRequest;
-import org.cotato.csquiz.api.attendance.dto.OnlineAttendanceRequest;
+import org.cotato.csquiz.api.attendance.dto.GenerationMemberAttendanceRecordResponse;
 import org.cotato.csquiz.api.attendance.dto.UpdateAttendanceRecordRequest;
 import org.cotato.csquiz.api.attendance.dto.UpdateAttendanceRequest;
 import org.cotato.csquiz.domain.attendance.service.AttendanceAdminService;
-import org.cotato.csquiz.domain.attendance.service.AttendanceRecordService;
 import org.cotato.csquiz.domain.attendance.service.AttendanceService;
 import org.cotato.csquiz.domain.attendance.util.AttendanceExcelHeaderUtil;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,7 +38,6 @@ public class AttendanceController {
 
     private final AttendanceAdminService attendanceAdminService;
     private final AttendanceService attendanceService;
-    private final AttendanceRecordService attendanceRecordService;
 
     @Operation(summary = "출석 단건 조회")
     @GetMapping("/{attendanceId}")
@@ -87,7 +78,7 @@ public class AttendanceController {
     public ResponseEntity<Void> updateAttendanceRecords(
             @PathVariable("attendance-id") Long attendanceId,
             @RequestBody @Valid UpdateAttendanceRecordRequest request) {
-        attendanceAdminService.updateAttendanceRecords(attendanceId, request.memberId(), request.attendanceResult());
+        attendanceAdminService.updateAttendanceRecords(attendanceId, request.memberId(), request.result());
         return ResponseEntity.noContent().build();
     }
 
@@ -98,58 +89,6 @@ public class AttendanceController {
         return ResponseEntity.ok().body(attendanceService.findAttendancesByGenerationId(generationId));
     }
 
-    @Operation(summary = "대면 출결 입력 API",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "성공"
-                    ),
-                    @ApiResponse(
-                            responseCode = "409",
-                            description = "이미 출석을 완료함"
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "출석 시간이 아님"
-                    )
-            }
-    )
-    @PostMapping(value = "/records/offline")
-    public ResponseEntity<AttendResponse> submitOfflineAttendanceRecord(
-            @RequestBody @Valid OfflineAttendanceRequest request,
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok().body(attendanceRecordService.submitRecord(request, memberId));
-    }
-
-    @Operation(summary = "비대면 출결 입력 API",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "성공"
-                    ),
-                    @ApiResponse(
-                            responseCode = "409",
-                            description = "이미 출석을 완료함"
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "출석 시간이 아님"
-                    )
-            })
-    @PostMapping(value = "/records/online")
-    public ResponseEntity<AttendResponse> submitOnlineAttendanceRecord(
-            @RequestBody @Valid OnlineAttendanceRequest request,
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok().body(attendanceRecordService.submitRecord(request, memberId));
-    }
-
-    @Operation(summary = "부원의 기수별 출결 기록 반환 API")
-    @GetMapping("/records/members")
-    public ResponseEntity<MemberAttendanceRecordsResponse> findAllRecordsByGeneration(
-            @RequestParam("generationId") Long generationId,
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok().body(attendanceRecordService.findAllRecordsBy(generationId, memberId));
-    }
 
     @Operation(summary = "세션별 출석 기록 엑셀 다운로드 API")
     @GetMapping("/excel")

--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceRecordController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceRecordController.java
@@ -3,7 +3,6 @@ package org.cotato.csquiz.api.attendance.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.persistence.Table;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.api.attendance.dto.AttendResponse;

--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceRecordController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceRecordController.java
@@ -1,0 +1,84 @@
+package org.cotato.csquiz.api.attendance.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.api.attendance.dto.AttendResponse;
+import org.cotato.csquiz.api.attendance.dto.MemberAttendanceRecordsResponse;
+import org.cotato.csquiz.api.attendance.dto.OfflineAttendanceRequest;
+import org.cotato.csquiz.api.attendance.dto.OnlineAttendanceRequest;
+import org.cotato.csquiz.domain.attendance.service.AttendanceRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "출결 기록", description = "출결 기록 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/api/attendances/record")
+public class AttendanceRecordController {
+
+    private final AttendanceRecordService attendanceRecordService;
+
+
+    @Operation(summary = "대면 출결 입력 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "409",
+                            description = "이미 출석을 완료함"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "출석 시간이 아님"
+                    )
+            }
+    )
+    @PostMapping(value = "/records/offline")
+    public ResponseEntity<AttendResponse> submitOfflineAttendanceRecord(
+            @RequestBody @Valid OfflineAttendanceRequest request,
+            @AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok().body(attendanceRecordService.submitRecord(request, memberId));
+    }
+
+    @Operation(summary = "비대면 출결 입력 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "409",
+                            description = "이미 출석을 완료함"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "출석 시간이 아님"
+                    )
+            })
+    @PostMapping(value = "/records/online")
+    public ResponseEntity<AttendResponse> submitOnlineAttendanceRecord(
+            @RequestBody @Valid OnlineAttendanceRequest request,
+            @AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok().body(attendanceRecordService.submitRecord(request, memberId));
+    }
+
+    @Operation(summary = "부원의 기수별 출결 기록 반환 API")
+    @GetMapping("/records/members")
+    public ResponseEntity<MemberAttendanceRecordsResponse> findAllRecordsByGeneration(
+            @RequestParam("generationId") Long generationId,
+            @AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok().body(attendanceRecordService.findAllRecordsBy(generationId, memberId));
+    }
+}

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendResponse.java
@@ -3,13 +3,13 @@ package org.cotato.csquiz.api.attendance.dto;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
 
 public record AttendResponse(
-        AttendanceResult status,
+        AttendanceResult result,
         String message
 ) {
-    public static AttendResponse from(AttendanceResult status) {
+    public static AttendResponse from(AttendanceResult result) {
         return new AttendResponse(
-                status,
-                status.getMessage()
+                result,
+                result.getMessage()
         );
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceTimeResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceTimeResponse.java
@@ -1,15 +1,17 @@
 package org.cotato.csquiz.api.attendance.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDateTime;
 import org.cotato.csquiz.domain.attendance.embedded.Location;
 import org.cotato.csquiz.domain.attendance.entity.Attendance;
 
 public record AttendanceTimeResponse(
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         Long sessionId,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         LocalDateTime attendanceDeadLine,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         LocalDateTime lateDeadLine,
         Location location
 ) {

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceWithSessionResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceWithSessionResponse.java
@@ -1,12 +1,16 @@
 package org.cotato.csquiz.api.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceOpenStatus;
 
 @Builder
 public record AttendanceWithSessionResponse(
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         Long sessionId,
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         Long attendanceId,
         String sessionTitle,
         LocalDateTime sessionDateTime,

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendancesResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendancesResponse.java
@@ -1,11 +1,15 @@
 package org.cotato.csquiz.api.attendance.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record AttendancesResponse(
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         Long generationId,
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         Long generationNumber,
         List<AttendanceWithSessionResponse> attendances
 ) {

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/MemberAttendResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/MemberAttendResponse.java
@@ -1,6 +1,7 @@
 package org.cotato.csquiz.api.attendance.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDateTime;
 import org.cotato.csquiz.domain.attendance.entity.Attendance;
 import org.cotato.csquiz.domain.attendance.entity.AttendanceRecord;
@@ -11,11 +12,11 @@ import org.cotato.csquiz.domain.attendance.util.AttendanceUtil;
 import org.cotato.csquiz.domain.generation.entity.Session;
 
 public record MemberAttendResponse(
-        @Schema(description = "세션 PK")
+        @Schema(description = "세션 PK", requiredMode = RequiredMode.REQUIRED)
         Long sessionId,
-        @Schema(description = "출석 PK")
+        @Schema(description = "출석 PK", requiredMode = RequiredMode.REQUIRED)
         Long attendanceId,
-        @Schema(description = "멤버 PK")
+        @Schema(description = "멤버 PK", requiredMode = RequiredMode.REQUIRED)
         Long memberId,
         @Schema(description = "세션 타이틀", example = "3주차 세션")
         String sessionTitle,
@@ -25,9 +26,9 @@ public record MemberAttendResponse(
                 "CLOSED", "OPEN"
         })
         AttendanceOpenStatus openStatus,
-        @Schema(description = "출결 형식", nullable = true)
+        @Schema(description = "출결 형식", nullable = true, requiredMode = RequiredMode.NOT_REQUIRED)
         AttendanceType attendanceType,
-        @Schema(description = "마감된 출석에 대한 출결 결과", nullable = true)
+        @Schema(description = "마감된 출석에 대한 출결 결과", nullable = true, requiredMode = RequiredMode.NOT_REQUIRED)
         AttendanceResult result
 ) {
     public static MemberAttendResponse unrecordedAttendance(Session session, Attendance attendance, Long memberId) {

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/MemberAttendResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/MemberAttendResponse.java
@@ -24,11 +24,11 @@ public record MemberAttendResponse(
         @Schema(description = "출결 진행 여부", examples = {
                 "CLOSED", "OPEN"
         })
-        AttendanceOpenStatus isOpened,
+        AttendanceOpenStatus openStatus,
         @Schema(description = "출결 형식", nullable = true)
         AttendanceType attendanceType,
         @Schema(description = "마감된 출석에 대한 출결 결과", nullable = true)
-        AttendanceResult attendanceResult
+        AttendanceResult result
 ) {
     public static MemberAttendResponse unrecordedAttendance(Session session, Attendance attendance, Long memberId) {
         return new MemberAttendResponse(

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/MemberAttendanceRecordsResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/MemberAttendanceRecordsResponse.java
@@ -1,10 +1,11 @@
 package org.cotato.csquiz.api.attendance.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.util.List;
 
 public record MemberAttendanceRecordsResponse(
-        @Schema(description = "요청한 기수 PK")
+        @Schema(description = "요청한 기수 PK", requiredMode = RequiredMode.REQUIRED)
         Long generationId,
         List<MemberAttendResponse> memberAttendResponses
 ) {

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/UpdateAttendanceRecordRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/UpdateAttendanceRecordRequest.java
@@ -4,6 +4,6 @@ import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
 
 public record UpdateAttendanceRecordRequest(
         Long memberId,
-        AttendanceResult attendanceResult
+        AttendanceResult result
 ) {
 }


### PR DESCRIPTION
- 출결 필드 API 필드명 통일
- 일부 클래스 records controller로 이동


### Todo
- [ ] attendanceAdminService의 메서드를 attendanceRecordService 로 이동 필요