### PR TITLE
[COT-111] Feature: 랜덤 퀴즈 테이블 생성

### DIFF
--- a/src/main/java/org/cotato/csquiz/domain/education/embedded/Choices.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/embedded/Choices.java
@@ -12,14 +12,14 @@ import lombok.NoArgsConstructor;
 public class Choices {
 
     @Column(nullable = false)
-    private String choice1;
+    private String firstChoice;
 
     @Column(nullable = false)
-    private String choice2;
+    private String secondChoice;
 
     @Column(nullable = false)
-    private String choice3;
+    private String thirdChoice;
 
     @Column(nullable = false)
-    private String choice4;
+    private String fourthChoice;
 }

--- a/src/main/java/org/cotato/csquiz/domain/education/embedded/Choices.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/embedded/Choices.java
@@ -1,0 +1,25 @@
+package org.cotato.csquiz.domain.education.embedded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Choices {
+
+    @Column(nullable = false)
+    private String choice1;
+
+    @Column(nullable = false)
+    private String choice2;
+
+    @Column(nullable = false)
+    private String choice3;
+
+    @Column(nullable = false)
+    private String choice4;
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/entity/RandomQuiz.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/entity/RandomQuiz.java
@@ -29,7 +29,7 @@ public class RandomQuiz extends BaseTimeEntity {
     @Column(name = "question", nullable = false, columnDefinition = "TEXT")
     private String question;
 
-    @Column(name = "image")
+    @Embedded
     private S3Info image;
 
     @Embedded

--- a/src/main/java/org/cotato/csquiz/domain/education/entity/RandomQuiz.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/entity/RandomQuiz.java
@@ -1,0 +1,40 @@
+package org.cotato.csquiz.domain.education.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.cotato.csquiz.common.entity.BaseTimeEntity;
+import org.cotato.csquiz.common.entity.S3Info;
+import org.cotato.csquiz.domain.education.embedded.Choices;
+import org.cotato.csquiz.domain.education.enums.QuizCategory;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RandomQuiz extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "category")
+    private QuizCategory category;
+
+    @Column(name = "question", nullable = false, columnDefinition = "TEXT")
+    private String question;
+
+    @Column(name = "image")
+    private S3Info image;
+
+    @Embedded
+    private Choices choices;
+
+    @Column(name = "answer_number", nullable = false)
+    private Integer answerNumber;
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/entity/RandomQuiz.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/entity/RandomQuiz.java
@@ -3,6 +3,8 @@ package org.cotato.csquiz.domain.education.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,7 +25,8 @@ public class RandomQuiz extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "category")
+    @Column(name = "category", nullable = false)
+    @Enumerated(EnumType.STRING)
     private QuizCategory category;
 
     @Column(name = "question", nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
@@ -1,0 +1,14 @@
+package org.cotato.csquiz.domain.education.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum QuizCategory {
+    NETWORK("네트워크"),
+    DB("데이터 베이스"),
+    OS("OS"),
+    OTHER("기타"),
+    ;
+
+    private final String description;
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
@@ -11,6 +11,7 @@ public enum QuizCategory {
     WEB("웹"),
     SECURITY("보안"),
     OTHER("기타"),
+    PL("프로그래밍 언어"),
     ;
 
     private final String description;

--- a/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
@@ -10,8 +10,8 @@ public enum QuizCategory {
     OOP("객체지향"),
     WEB("웹"),
     SECURITY("보안"),
-    OTHER("기타"),
     PL("프로그래밍 언어"),
+    OTHER("기타"),
     ;
 
     private final String description;

--- a/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
@@ -7,6 +7,9 @@ public enum QuizCategory {
     NETWORK("네트워크"),
     DB("데이터 베이스"),
     OS("운영 체제"),
+    OOP("객체지향"),
+    WEB("웹"),
+    SECURITY("보안"),
     OTHER("기타"),
     ;
 

--- a/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/enums/QuizCategory.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 public enum QuizCategory {
     NETWORK("네트워크"),
     DB("데이터 베이스"),
-    OS("OS"),
+    OS("운영 체제"),
     OTHER("기타"),
     ;
 


### PR DESCRIPTION
## 연관된 이슈

이슈링크(url): 


## ✅ 작업 내용
랜덤 퀴즈 테이블 생성

## 🗣 ️리뷰 요구 사항
현재 퀴즈 카테고리 목록은 다음과 같은데 추가할만한 항목 있으면 말해주세요
```
    NETWORK("네트워크"),
    DB("데이터 베이스"),
    OS("OS"),
    OTHER("기타"),
```

## DDL
```
CREATE TABLE random_quiz (
    id BIGINT AUTO_INCREMENT PRIMARY KEY,
    created_at DATETIME(6) NULL,
    modified_at DATETIME(6) NULL,
    answer_number INT NOT NULL,
    category SMALLINT NOT NULL,
    choice1 VARCHAR(255) NOT NULL,
    choice2 VARCHAR(255) NOT NULL,
    choice3 VARCHAR(255) NOT NULL,
    choice4 VARCHAR(255) NOT NULL,
    file_name VARCHAR(255) NULL,
    folder_name VARCHAR(255) NULL,
    url VARCHAR(255) NULL,
    question TEXT NOT NULL
);
```