### PR TITLE
[COT-123] Feature: 출석 단건 조회에 세션 타입 추가 및 기수별 목록 조회에 openStatus 제거

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceResponse.java
@@ -8,6 +8,7 @@ import org.cotato.csquiz.domain.attendance.entity.Attendance;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceOpenStatus;
 import org.cotato.csquiz.domain.attendance.util.AttendanceUtil;
 import org.cotato.csquiz.domain.generation.entity.Session;
+import org.cotato.csquiz.domain.generation.enums.SessionType;
 
 public record AttendanceResponse(
         @Schema(description = "출석 PK", requiredMode = RequiredMode.REQUIRED)
@@ -20,6 +21,8 @@ public record AttendanceResponse(
         Location location,
         @Schema(description = "세션 PK", requiredMode = RequiredMode.REQUIRED)
         Long sessionId,
+        @Schema(description = "출결 옵션", requiredMode = RequiredMode.REQUIRED)
+        SessionType sessionType,
         @Schema(description = "출석 오픈 상태", requiredMode = RequiredMode.REQUIRED)
         AttendanceOpenStatus openStatus
 ) {
@@ -30,6 +33,7 @@ public record AttendanceResponse(
                 attendance.getLateDeadLine(),
                 attendance.getLocation(),
                 attendance.getSessionId(),
+                session.getSessionType(),
                 AttendanceUtil.getAttendanceOpenStatus(session.getSessionDateTime(), attendance, LocalDateTime.now())
         );
     }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceWithSessionResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceWithSessionResponse.java
@@ -18,8 +18,6 @@ public record AttendanceWithSessionResponse(
         @Schema(requiredMode = RequiredMode.NOT_REQUIRED)
         LocalDateTime sessionDateTime,
         @Schema(requiredMode = RequiredMode.REQUIRED)
-        SessionType sessionType,
-        @Schema(requiredMode = RequiredMode.REQUIRED)
-        AttendanceOpenStatus openStatus
+        SessionType sessionType
 ) {
 }

--- a/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceWithSessionResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/dto/AttendanceWithSessionResponse.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceOpenStatus;
+import org.cotato.csquiz.domain.generation.enums.SessionType;
 
 @Builder
 public record AttendanceWithSessionResponse(
@@ -12,8 +13,13 @@ public record AttendanceWithSessionResponse(
         Long sessionId,
         @Schema(requiredMode = RequiredMode.REQUIRED)
         Long attendanceId,
+        @Schema(requiredMode = RequiredMode.NOT_REQUIRED)
         String sessionTitle,
+        @Schema(requiredMode = RequiredMode.NOT_REQUIRED)
         LocalDateTime sessionDateTime,
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        SessionType sessionType,
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         AttendanceOpenStatus openStatus
 ) {
 }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -82,7 +83,8 @@ public class AttendanceService {
 
         List<AttendanceWithSessionResponse> attendances = attendanceRepository.findAllBySessionIdsInQuery(sessionIds).stream()
                 .map(at -> {
-                    final Session session = sessionById .get(at.getSessionId());
+                    final Session session = Optional.ofNullable(sessionById.get(at.getSessionId()))
+                                .orElseThrow(() -> new EntityNotFoundException("출석에 연결된 세션을 찾을 수 없습니다."));
 
                     return AttendanceWithSessionResponse.builder()
                         .attendanceId(at.getId())

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -81,13 +81,18 @@ public class AttendanceService {
         LocalDateTime currentTime = LocalDateTime.now();
 
         List<AttendanceWithSessionResponse> attendances = attendanceRepository.findAllBySessionIdsInQuery(sessionIds).stream()
-                .map(at -> AttendanceWithSessionResponse.builder()
+                .map(at -> {
+                    final Session session = sessionMap .get(at.getSessionId());
+
+                    return AttendanceWithSessionResponse.builder()
                         .attendanceId(at.getId())
+                        .sessionType(session.getSessionType())
                         .sessionId(at.getSessionId())
-                        .sessionTitle(sessionMap.get(at.getSessionId()).getTitle())
-                        .sessionDateTime(sessionMap.get(at.getSessionId()).getSessionDateTime())
-                        .openStatus(AttendanceUtil.getAttendanceOpenStatus(sessionMap.get(at.getSessionId()).getSessionDateTime(), at, currentTime))
-                        .build())
+                        .sessionTitle(session.getTitle())
+                        .sessionDateTime(session.getSessionDateTime())
+                        .openStatus(AttendanceUtil.getAttendanceOpenStatus(session.getSessionDateTime(), at, currentTime))
+                        .build();
+                })
                 .toList();
 
         return AttendancesResponse.builder()

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -71,7 +71,7 @@ public class AttendanceService {
 
         List<Session> sessions = sessionRepository.findAllByGenerationId(generationId);
 
-        Map<Long, Session> sessionMap = sessions.stream()
+        Map<Long, Session> sessionById = sessions.stream()
                 .collect(Collectors.toMap(Session::getId, Function.identity()));
 
         List<Long> sessionIds = sessions.stream()
@@ -82,7 +82,7 @@ public class AttendanceService {
 
         List<AttendanceWithSessionResponse> attendances = attendanceRepository.findAllBySessionIdsInQuery(sessionIds).stream()
                 .map(at -> {
-                    final Session session = sessionMap .get(at.getSessionId());
+                    final Session session = sessionById .get(at.getSessionId());
 
                     return AttendanceWithSessionResponse.builder()
                         .attendanceId(at.getId())

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceService.java
@@ -79,8 +79,6 @@ public class AttendanceService {
                 .map(Session::getId)
                 .toList();
 
-        LocalDateTime currentTime = LocalDateTime.now();
-
         List<AttendanceWithSessionResponse> attendances = attendanceRepository.findAllBySessionIdsInQuery(sessionIds).stream()
                 .map(at -> {
                     final Session session = Optional.ofNullable(sessionById.get(at.getSessionId()))
@@ -92,7 +90,6 @@ public class AttendanceService {
                         .sessionId(at.getSessionId())
                         .sessionTitle(session.getTitle())
                         .sessionDateTime(session.getSessionDateTime())
-                        .openStatus(AttendanceUtil.getAttendanceOpenStatus(session.getSessionDateTime(), at, currentTime))
                         .build();
                 })
                 .toList();


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

- 출석 단건 조회에 sessionType을 반환한다.
- 기수별 단건 조회엔 openStatus가 필요없다

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->


### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-123

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->