### PR TITLE
[COT-121] Feature: AuthPrincipal Context를 Member로 수정

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceRecordController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceRecordController.java
@@ -10,6 +10,7 @@ import org.cotato.csquiz.api.attendance.dto.MemberAttendanceRecordsResponse;
 import org.cotato.csquiz.api.attendance.dto.OfflineAttendanceRequest;
 import org.cotato.csquiz.api.attendance.dto.OnlineAttendanceRequest;
 import org.cotato.csquiz.domain.attendance.service.AttendanceRecordService;
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,8 +48,8 @@ public class AttendanceRecordController {
     @PostMapping(value = "/offline")
     public ResponseEntity<AttendResponse> submitOfflineAttendanceRecord(
             @RequestBody @Valid OfflineAttendanceRequest request,
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok().body(attendanceRecordService.submitRecord(request, memberId));
+            @AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok().body(attendanceRecordService.submitRecord(request, member));
     }
 
     @Operation(summary = "비대면 출결 입력 API",
@@ -69,15 +70,15 @@ public class AttendanceRecordController {
     @PostMapping(value = "/online")
     public ResponseEntity<AttendResponse> submitOnlineAttendanceRecord(
             @RequestBody @Valid OnlineAttendanceRequest request,
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok().body(attendanceRecordService.submitRecord(request, memberId));
+            @AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok().body(attendanceRecordService.submitRecord(request, member));
     }
 
     @Operation(summary = "부원의 기수별 출결 기록 반환 API")
     @GetMapping("/members")
     public ResponseEntity<MemberAttendanceRecordsResponse> findAllRecordsByGeneration(
             @RequestParam("generationId") Long generationId,
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok().body(attendanceRecordService.findAllRecordsBy(generationId, memberId));
+            @AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok().body(attendanceRecordService.findAllRecordsBy(generationId, member));
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/auth/controller/AuthController.java
+++ b/src/main/java/org/cotato/csquiz/api/auth/controller/AuthController.java
@@ -42,7 +42,6 @@ public class AuthController {
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> tokenReissue(@CookieValue(name = "refreshToken") String refreshToken,
                                                         HttpServletResponse response) {
-        log.info("[액세스 토큰 재발급 컨트롤러]: 쿠키 존재 여부, {}", !refreshToken.isEmpty());
         return ResponseEntity.ok().body(authService.reissue(refreshToken, response));
     }
 
@@ -55,7 +54,6 @@ public class AuthController {
 
     @PostMapping(value = "/verification", params = "type=sign-up")
     public ResponseEntity<Void> sendSignUpVerificationCode(@Valid @RequestBody SendEmailRequest request) {
-        log.info("[회원 가입 시 이메일 인증 요청 컨트롤러]: 요청된 이메일 {}", request.email());
         authService.sendSignUpEmail(request);
         return ResponseEntity.noContent().build();
     }
@@ -63,7 +61,6 @@ public class AuthController {
     @GetMapping(value = "/verification", params = "type=sign-up")
     public ResponseEntity<Void> verifyCode(@RequestParam(name = "email") String email,
                                            @RequestParam(name = "code") String code) {
-        log.info("[회원 가입 시 인증 코드 확인 컨트롤러]: {}", email);
         authService.verifySingUpCode(email, code);
         return ResponseEntity.noContent().build();
     }
@@ -83,7 +80,6 @@ public class AuthController {
     @GetMapping("/email")
     public ResponseEntity<MemberEmailResponse> findEmail(@RequestParam(name = "name") String name,
                                                          @RequestParam("phone") String phoneNumber) {
-        log.info("아이디 찾기 컨트롤러: {}", name);
         return ResponseEntity.ok(authService.findMemberEmail(name, phoneNumber));
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/education/controller/EducationController.java
+++ b/src/main/java/org/cotato/csquiz/api/education/controller/EducationController.java
@@ -70,20 +70,17 @@ public class EducationController {
 
     @PostMapping("/kings")
     public ResponseEntity<Void> calculateKingMembers(@RequestParam("educationId") Long educationId) {
-        log.info("[{} 교육 결승진출자 계산하기]", educationId);
         kingMemberService.saveKingMember(educationId);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/winner")
     public ResponseEntity<WinnerInfoResponse> findWinner(@RequestParam("educationId") Long educationId) {
-        log.info("[{} 교육 우승자 조회 컨트롤러]", educationId);
         return ResponseEntity.ok().body(kingMemberService.findWinner(educationId));
     }
 
     @PostMapping("/winner")
     public ResponseEntity<Void> calculateWinner(@RequestParam("educationId") Long educationId) {
-        log.info("[{} 교육 우승자 계산]", educationId);
         kingMemberService.calculateWinner(educationId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/cotato/csquiz/api/generation/controller/GenerationController.java
+++ b/src/main/java/org/cotato/csquiz/api/generation/controller/GenerationController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "기수 관련 API")
 @RestController
-@RequestMapping("/v1/api/generation")
+@RequestMapping("/v1/api/generations")
 @RequiredArgsConstructor
 @Slf4j
 public class GenerationController {
@@ -48,7 +48,7 @@ public class GenerationController {
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/period")
+    @PatchMapping("/{generationId}/period")
     public ResponseEntity<Void> changeGenerationPeriod(@RequestBody @Valid ChangeGenerationPeriodRequest request) {
         generationService.changeGenerationPeriod(request);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import org.cotato.csquiz.api.member.dto.UpdatePasswordRequest;
 import org.cotato.csquiz.api.member.dto.UpdatePhoneNumberRequest;
 import org.cotato.csquiz.api.member.dto.UpdateProfileImageRequest;
 import org.cotato.csquiz.common.error.exception.ImageException;
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,34 +38,34 @@ public class MemberController {
     }
 
     @PatchMapping("/update/password")
-    public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal Long memberId,
+    public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal Member member,
                                                @RequestBody @Valid UpdatePasswordRequest request) {
-        memberService.updatePassword(memberId, request.password());
+        memberService.updatePassword(member, request.password());
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "멤버 전화번호 수정 API")
     @PatchMapping("/phone-number")
-    public ResponseEntity<Void> updatePhoneNumber(@AuthenticationPrincipal Long memberId,
+    public ResponseEntity<Void> updatePhoneNumber(@AuthenticationPrincipal Member member,
                                                   @RequestBody @Valid UpdatePhoneNumberRequest request) {
-        memberService.updatePhoneNumber(memberId, request.phoneNumber());
+        memberService.updatePhoneNumber(member, request.phoneNumber());
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "멤버 프로필 사진 수정 API")
     @PatchMapping(value = "/profile-image", consumes = "multipart/form-data")
     public ResponseEntity<Void> updateProfileImage(
-            @AuthenticationPrincipal Long memberId,
+            @AuthenticationPrincipal Member member,
             @ModelAttribute @Valid UpdateProfileImageRequest request) throws ImageException {
-        memberService.updateMemberProfileImage(memberId, request.image());
+        memberService.updateMemberProfileImage(member, request.image());
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "멤버 프로필 사진 삭제 API")
     @DeleteMapping("/profile-image")
     public ResponseEntity<Void> deleteProfileImage(
-            @AuthenticationPrincipal Long memberId) {
-        memberService.deleteMemberProfileImage(memberId);
+            @AuthenticationPrincipal Member member) {
+        memberService.deleteMemberProfileImage(member);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/cotato/csquiz/api/mypage/controller/MyPageController.java
+++ b/src/main/java/org/cotato/csquiz/api/mypage/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package org.cotato.csquiz.api.mypage.controller;
 
 import org.cotato.csquiz.api.mypage.dto.HallOfFameResponse;
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.education.service.MyPageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,7 @@ public class MyPageController {
 
     @GetMapping("/hall-of-fame")
     public ResponseEntity<HallOfFameResponse> findHallOfFame(@RequestParam("generationId") Long generationId,
-                                                             @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(myPageService.findHallOfFame(generationId, memberId));
+                                                             @AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok(myPageService.findHallOfFame(generationId, member));
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/policy/controller/PolicyController.java
+++ b/src/main/java/org/cotato/csquiz/api/policy/controller/PolicyController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.api.policy.dto.CheckMemberPoliciesRequest;
 import org.cotato.csquiz.api.policy.dto.FindMemberPolicyResponse;
 import org.cotato.csquiz.api.policy.dto.PoliciesResponse;
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.service.PolicyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,15 +27,15 @@ public class PolicyController {
 
     @Operation(summary = "체크하지 않은 정책 조회 API")
     @GetMapping("/essential")
-    public ResponseEntity<FindMemberPolicyResponse> getUnCheckedPolicies(@AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok().body(policyService.findUnCheckedPolicies(memberId));
+    public ResponseEntity<FindMemberPolicyResponse> getUnCheckedPolicies(@AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok().body(policyService.findUnCheckedPolicies(member));
     }
 
     @Operation(summary = "특정 정책에 대해 동의 여부 체크 API")
     @PostMapping("/check")
     public ResponseEntity<Void> checkPolicies(@RequestBody @Valid CheckMemberPoliciesRequest request,
-                                              @AuthenticationPrincipal Long memberId) {
-        policyService.checkPolicies(memberId, request.policies());
+                                              @AuthenticationPrincipal Member member) {
+        policyService.checkPolicies(member, request.policies());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/cotato/csquiz/api/policy/dto/FindMemberPolicyResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/policy/dto/FindMemberPolicyResponse.java
@@ -2,6 +2,7 @@ package org.cotato.csquiz.api.policy.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import org.cotato.csquiz.domain.auth.entity.Member;
 
 public record FindMemberPolicyResponse(
         Long memberId,
@@ -10,8 +11,8 @@ public record FindMemberPolicyResponse(
         @Schema(description = "회원이 체크하지 않은 선택 정책 목록")
         List<PolicyInfoResponse> optionalPolicies
 ) {
-    public static FindMemberPolicyResponse of(Long memberId, List<PolicyInfoResponse> essentialPolicies,
+    public static FindMemberPolicyResponse of(Member member, List<PolicyInfoResponse> essentialPolicies,
                                               List<PolicyInfoResponse> optionalPolicies) {
-        return new FindMemberPolicyResponse(memberId, essentialPolicies, optionalPolicies);
+        return new FindMemberPolicyResponse(member.getId(), essentialPolicies, optionalPolicies);
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/session/dto/UpdateSessionRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/session/dto/UpdateSessionRequest.java
@@ -3,6 +3,7 @@ package org.cotato.csquiz.api.session.dto;
 import static org.cotato.csquiz.domain.attendance.enums.DeadLine.DEFAULT_ATTENDANCE_DEADLINE;
 import static org.cotato.csquiz.domain.attendance.enums.DeadLine.DEFAULT_LATE_DEADLINE;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import org.cotato.csquiz.api.attendance.dto.AttendanceDeadLineDto;
@@ -11,7 +12,6 @@ import org.cotato.csquiz.domain.generation.enums.CSEducation;
 import org.cotato.csquiz.domain.generation.enums.DevTalk;
 import org.cotato.csquiz.domain.generation.enums.ItIssue;
 import org.cotato.csquiz.domain.generation.enums.Networking;
-import jakarta.validation.constraints.NotNull;
 
 public record UpdateSessionRequest(
         @NotNull

--- a/src/main/java/org/cotato/csquiz/api/socket/controller/SocketController.java
+++ b/src/main/java/org/cotato/csquiz/api/socket/controller/SocketController.java
@@ -7,6 +7,7 @@ import org.cotato.csquiz.api.socket.dto.EducationCloseRequest;
 import org.cotato.csquiz.api.socket.dto.EducationOpenRequest;
 import org.cotato.csquiz.api.socket.dto.QuizSocketRequest;
 import org.cotato.csquiz.api.socket.dto.SocketTokenDto;
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.education.service.EducationService;
 import org.cotato.csquiz.domain.education.service.QuizSolveService;
 import org.cotato.csquiz.domain.education.service.RecordService;
@@ -69,8 +70,8 @@ public class SocketController {
     }
 
     @PostMapping("/token")
-    public ResponseEntity<SocketTokenDto> makeSocketToken(@AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(socketService.createSocketToken(memberId));
+    public ResponseEntity<SocketTokenDto> makeSocketToken(@AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok(socketService.createSocketToken(member));
     }
 
 

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
@@ -10,6 +10,8 @@ import jodd.net.HttpMethod;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.common.config.jwt.JwtTokenProvider;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.service.component.MemberReader;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -40,6 +42,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    private final MemberReader memberReader;
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -52,14 +56,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     }
 
     private void setAuthentication(String accessToken) {
-        Long memberId = jwtTokenProvider.getMemberId(accessToken);
-        String role = jwtTokenProvider.getRole(accessToken);
-        log.info("[인증 필터 인증 진행, {}]", memberId);
+        Member member = jwtTokenProvider.getMemberByToken(accessToken);
+        String role = member.getRole().toString();
+//        log.info("[인증 필터 인증 진행, {}]", memberId);
         log.info("Member Role: {}", role);
 
-        jwtTokenProvider.checkMemberExist(memberId);
-
-        Authentication authenticationToken = new UsernamePasswordAuthenticationToken(memberId, "",
+        Authentication authenticationToken = new UsernamePasswordAuthenticationToken(member, "",
                 List.of(new SimpleGrantedAuthority(role)));
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
     }

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.common.config.jwt.JwtTokenProvider;
 import org.cotato.csquiz.domain.auth.entity.Member;
-import org.cotato.csquiz.domain.auth.service.component.MemberReader;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -42,8 +41,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    private final MemberReader memberReader;
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -58,8 +55,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private void setAuthentication(String accessToken) {
         Member member = jwtTokenProvider.getMemberByToken(accessToken);
         String role = member.getRole().toString();
-//        log.info("[인증 필터 인증 진행, {}]", memberId);
-        log.info("Member Role: {}", role);
+        log.info("authenticated member : <{}> , <{}>", member.getId(), member.getName());
 
         Authentication authenticationToken = new UsernamePasswordAuthenticationToken(member, "",
                 List.of(new SimpleGrantedAuthority(role)));

--- a/src/main/java/org/cotato/csquiz/common/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/cotato/csquiz/common/config/jwt/JwtTokenProvider.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.domain.auth.constant.TokenConstants;
 import org.cotato.csquiz.common.error.exception.FilterAuthenticationException;
 import org.cotato.csquiz.common.error.exception.InterceptorException;
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -149,5 +150,10 @@ public class JwtTokenProvider {
     public Long getMemberId(String token) {
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
                 .getBody().get("id", Long.class);
+    }
+
+    public Member getMemberByToken(String token) {
+        Long memberId = getMemberId(token);
+        return memberRepository.findById(memberId).orElseThrow();
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/cotato/csquiz/common/config/jwt/JwtTokenProvider.java
@@ -108,12 +108,6 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public void checkMemberExist(Long id) {
-        if (!memberRepository.existsById(id)) {
-            throw new FilterAuthenticationException("존재하지 않는 회원입니다.");
-        }
-    }
-
     public String createSocketToken(Long id, String role) {
         Claims claims = Jwts.claims();
         claims.put("id", id);
@@ -154,6 +148,6 @@ public class JwtTokenProvider {
 
     public Member getMemberByToken(String token) {
         Long memberId = getMemberId(token);
-        return memberRepository.findById(memberId).orElseThrow();
+        return memberRepository.findById(memberId).orElseThrow(() -> new FilterAuthenticationException("존재하지 않는 회원입니다."));
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/websocket/WebSocketHandler.java
+++ b/src/main/java/org/cotato/csquiz/common/websocket/WebSocketHandler.java
@@ -1,6 +1,7 @@
 package org.cotato.csquiz.common.websocket;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
@@ -41,6 +42,8 @@ public class WebSocketHandler extends TextWebSocketHandler {
     private static final String MEMBER_ID_KEY = "memberId";
     private static final String EDUCATION_ID_KEY = "educationId";
     private static final String ROLE_KEY = "role";
+
+    private static final String KEY_DELIMITER = "@";
     private static final CloseStatus ATTEMPT_NEW_CONNECTION = new CloseStatus(4001, "new connection request");
 
     private final QuizRepository quizRepository;

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
@@ -69,7 +69,7 @@ public class AuthService {
                 .build();
         memberRepository.save(newMember);
 
-        policyService.checkPolicies(newMember.getId(), request.policies());
+        policyService.checkPolicies(newMember, request.policies());
 
         return JoinResponse.from(newMember);
     }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -57,14 +57,11 @@ public class MemberService {
     }
 
     @Transactional
-    public void updatePassword(final Long memberId, final String password) {
-        Member findMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
-
+    public void updatePassword(final Member member, final String password) {
         validateService.checkPasswordPattern(password);
-        validateIsSameBefore(findMember.getPassword(), password);
+        validateIsSameBefore(member.getPassword(), password);
 
-        findMember.updatePassword(bCryptPasswordEncoder.encode(password));
+        member.updatePassword(bCryptPasswordEncoder.encode(password));
     }
 
     private void validateIsSameBefore(String originPassword, String newPassword) {
@@ -74,41 +71,32 @@ public class MemberService {
     }
 
     @Transactional
-    public void updatePhoneNumber(Long memberId, String phoneNumber) {
-        Member findMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
-
+    public void updatePhoneNumber(final Member member, String phoneNumber) {
         String encryptedPhoneNumber = encryptService.encryptPhoneNumber(phoneNumber);
-        findMember.updatePhoneNumber(encryptedPhoneNumber);
+        member.updatePhoneNumber(encryptedPhoneNumber);
     }
 
     @Transactional
-    public void updateMemberProfileImage(Long memberId, MultipartFile image) throws ImageException {
+    public void updateMemberProfileImage(final Member member, MultipartFile image) throws ImageException {
         if (image.isEmpty()) {
             throw new AppException(ErrorCode.FILE_IS_EMPTY);
         }
 
-        Member findMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
-
-        if (findMember.getProfileImage() != null) {
-            s3Uploader.deleteFile(findMember.getProfileImage());
+        if (member.getProfileImage() != null) {
+            s3Uploader.deleteFile(member.getProfileImage());
         }
 
         S3Info s3Info = s3Uploader.uploadFiles(image, PROFILE_BUCKET_DIRECTORY);
-        findMember.updateProfileImage(s3Info);
+        member.updateProfileImage(s3Info);
     }
 
     @Transactional
-    public void deleteMemberProfileImage(Long memberId) {
-        Member findMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
-
-        if (findMember.getProfileImage() != null) {
-            s3Uploader.deleteFile(findMember.getProfileImage());
+    public void deleteMemberProfileImage(final Member member) {
+        if (member.getProfileImage() != null) {
+            s3Uploader.deleteFile(member.getProfileImage());
         }
 
-        findMember.updateProfileImage(null);
+        member.updateProfileImage(null);
     }
 
     public MemberMyPageInfoResponse findMyPageInfo(Long memberId) {

--- a/src/main/java/org/cotato/csquiz/domain/education/service/MyPageService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/MyPageService.java
@@ -42,7 +42,7 @@ public class MyPageService {
     private final RecordRepository recordRepository;
     private final ScorerRepository scorerRepository;
 
-    public HallOfFameResponse findHallOfFame(Long generationId, Long memberId) {
+    public HallOfFameResponse findHallOfFame(Long generationId, final Member member) {
         Generation findGeneration = generationRepository.findById(generationId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 기수를 찾을 수 없습니다."));
 
@@ -51,7 +51,6 @@ public class MyPageService {
         log.info("============{}기에 존재하는 모든 정답자 조회================", findGeneration.getNumber());
         List<HallOfFameInfo> answerHallOfFame = createRecordsHallOfFameInfoByGeneration(findGeneration);
 
-        Member member = findMemberById(memberId);
         MyHallOfFameInfo myHallOfFameInfo = createMyHallOfFameInfoByGeneration(member, findGeneration);
 
         return HallOfFameResponse.of(scorerHallOfFame, answerHallOfFame, myHallOfFameInfo);

--- a/src/main/java/org/cotato/csquiz/domain/education/service/SocketService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/SocketService.java
@@ -34,9 +34,7 @@ public class SocketService {
         webSocketHandler.stopEducation(educationId);
     }
 
-    public SocketTokenDto createSocketToken(final Long memberId) {
-        Member member = memberService.findById(memberId);
-
+    public SocketTokenDto createSocketToken(final Member member) {
         String socketToken = jwtTokenProvider.createSocketToken(member.getId(), member.getRole().getKey());
         log.info("[ 소켓 전용 토큰 발급 완료 ]");
         return SocketTokenDto.from(socketToken);


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

필터에서 인증 시 SecurityContextHolder에 Member ID만 저장한다.
이로 인해 불필요하게 멤버 조회를 계속함

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

변경하자.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

resolve: https://youthing.atlassian.net/jira/software/projects/COT/boards/2?atlOrigin=eyJpIjoiYzc2YzEwZGU3OTJmNDYyNjgzYWZmZDBhMWY2ZmEyMjkiLCJwIjoiSmlyYS1Ob3Rpb25EQnN5bi1JbnQifQ&selectedIssue=COT-121

### Test (option)
<!-- 테스트 결과를 보여주세요. -->

너무 많아서 QA에서 테스트 진행


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->