### PR TITLE
[COT-124] Feature: profile card info

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.cotato.csquiz.api.member.dto.MemberMyPageInfoResponse;
 import org.cotato.csquiz.api.member.dto.UpdatePasswordRequest;
 import org.cotato.csquiz.api.member.dto.UpdatePhoneNumberRequest;
 import org.cotato.csquiz.api.member.dto.UpdateProfileImageRequest;
+import org.cotato.csquiz.api.member.dto.UpdateProfileInfoRequest;
 import org.cotato.csquiz.common.error.exception.ImageException;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.service.MemberService;
@@ -49,6 +50,15 @@ public class MemberController {
     public ResponseEntity<Void> updatePhoneNumber(@AuthenticationPrincipal Member member,
                                                   @RequestBody @Valid UpdatePhoneNumberRequest request) {
         memberService.updatePhoneNumber(member, request.phoneNumber());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "멤버 프로필 정보 수정 API")
+    @PatchMapping("/profile")
+    public ResponseEntity<Void> updateProfileInfo(@AuthenticationPrincipal Long memberId,
+                                                  @RequestBody @Valid final UpdateProfileInfoRequest request) {
+        memberService.updateMemberProfileInfo(memberId, request.introduction(), request.university(),
+                request.profileLinks());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -55,9 +55,9 @@ public class MemberController {
 
     @Operation(summary = "멤버 프로필 정보 수정 API")
     @PatchMapping("/profile")
-    public ResponseEntity<Void> updateProfileInfo(@AuthenticationPrincipal Long memberId,
+    public ResponseEntity<Void> updateProfileInfo(@AuthenticationPrincipal Member member,
                                                   @RequestBody @Valid final UpdateProfileInfoRequest request) {
-        memberService.updateMemberProfileInfo(memberId, request.introduction(), request.university(),
+        memberService.updateMemberProfileInfo(member, request.introduction(), request.university(),
                 request.profileLinks());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/cotato/csquiz/api/member/dto/ProfileLinkRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/ProfileLinkRequest.java
@@ -1,0 +1,14 @@
+package org.cotato.csquiz.api.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.cotato.csquiz.domain.auth.enums.LinkType;
+
+public record ProfileLinkRequest(
+        @NotNull(message = "링크 타입을 지정해주세요")
+        LinkType linkType,
+
+        @NotBlank(message = "링크를 입력해주세요")
+        String link
+) {
+}

--- a/src/main/java/org/cotato/csquiz/api/member/dto/UpdateProfileInfoRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/UpdateProfileInfoRequest.java
@@ -1,0 +1,16 @@
+package org.cotato.csquiz.api.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record UpdateProfileInfoRequest(
+        @Schema(description = "자기 소개")
+        String introduction,
+
+        @Schema(description = "소속 학교")
+        String university,
+
+        @Schema(description = "링크 목록")
+        List<ProfileLinkRequest> profileLinks
+) {
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/entity/ProfileLink.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/entity/ProfileLink.java
@@ -29,9 +29,12 @@ public class ProfileLink extends BaseTimeEntity {
 
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
-    private LinkType role;
+    private LinkType linkType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @Column(name = "link", nullable = false, columnDefinition = "TEXT")
+    private String link;
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/entity/ProfileLink.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/entity/ProfileLink.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cotato.csquiz.common.entity.BaseTimeEntity;
@@ -35,6 +34,16 @@ public class ProfileLink extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(name = "link", nullable = false, columnDefinition = "TEXT")
-    private String link;
+    @Column(name = "url", nullable = false, columnDefinition = "TEXT")
+    private String url;
+
+    private ProfileLink(Member member, LinkType linkType, String link) {
+        this.member = member;
+        this.linkType = linkType;
+        this.url = link;
+    }
+
+    public static ProfileLink of(final Member member, LinkType linkType, String link) {
+        return new ProfileLink(member, linkType, link);
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/repository/ProfileLinkRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/repository/ProfileLinkRepository.java
@@ -1,7 +1,9 @@
 package org.cotato.csquiz.domain.auth.repository;
 
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.entity.ProfileLink;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProfileLinkRepository extends JpaRepository<ProfileLink, Long> {
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -8,16 +8,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.api.admin.dto.MemberInfoResponse;
 import org.cotato.csquiz.api.member.dto.MemberInfo;
 import org.cotato.csquiz.api.member.dto.MemberMyPageInfoResponse;
-import org.cotato.csquiz.common.config.jwt.JwtTokenProvider;
+import org.cotato.csquiz.api.member.dto.ProfileLinkRequest;
 import org.cotato.csquiz.common.entity.S3Info;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.common.error.exception.ImageException;
 import org.cotato.csquiz.common.s3.S3Uploader;
 import org.cotato.csquiz.domain.auth.entity.Member;
-import org.cotato.csquiz.domain.auth.enums.MemberRoleGroup;
+import org.cotato.csquiz.domain.auth.entity.ProfileLink;
 import org.cotato.csquiz.domain.auth.repository.MemberRepository;
 import org.cotato.csquiz.domain.auth.service.component.MemberReader;
+import org.cotato.csquiz.domain.auth.service.component.ProfileLinkWriter;
 import org.cotato.csquiz.domain.generation.entity.Generation;
 import org.cotato.csquiz.domain.generation.service.component.GenerationReader;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -34,6 +35,7 @@ public class MemberService {
     private static final String PROFILE_BUCKET_DIRECTORY = "profile";
     private final MemberReader memberReader;
     private final GenerationReader generationReader;
+    private final ProfileLinkWriter profileLinkWriter;
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final EncryptService encryptService;
@@ -74,6 +76,21 @@ public class MemberService {
     public void updatePhoneNumber(final Member member, String phoneNumber) {
         String encryptedPhoneNumber = encryptService.encryptPhoneNumber(phoneNumber);
         member.updatePhoneNumber(encryptedPhoneNumber);
+    }
+
+    @Transactional
+    public void updateMemberProfileInfo(final Long memberId, final String introduction, final String university,
+                                        final List<ProfileLinkRequest> profileLinkRequests) {
+        Member member = memberReader.findById(memberId);
+
+        member.updateIntroduction(introduction);
+        member.updateUniversity(university);
+        profileLinkWriter.deleteAllByMember(member);
+
+        List<ProfileLink> profileLinks = profileLinkRequests.stream()
+                .map(lr -> ProfileLink.of(member, lr.linkType(), lr.link()))
+                .toList();
+        profileLinkWriter.createProfileLinks(profileLinks);
     }
 
     @Transactional

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -18,6 +18,7 @@ import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.entity.ProfileLink;
 import org.cotato.csquiz.domain.auth.repository.MemberRepository;
 import org.cotato.csquiz.domain.auth.service.component.MemberReader;
+import org.cotato.csquiz.domain.auth.service.component.MemberWriter;
 import org.cotato.csquiz.domain.auth.service.component.ProfileLinkWriter;
 import org.cotato.csquiz.domain.generation.entity.Generation;
 import org.cotato.csquiz.domain.generation.service.component.GenerationReader;
@@ -41,6 +42,7 @@ public class MemberService {
     private final EncryptService encryptService;
     private final ValidateService validateService;
     private final S3Uploader s3Uploader;
+    private final MemberWriter memberWriter;
 
     public MemberInfoResponse findMemberInfo(Long id) {
         Member findMember = memberRepository.findById(id)
@@ -79,14 +81,13 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateMemberProfileInfo(final Long memberId, final String introduction, final String university,
+    public void updateMemberProfileInfo(final Member member, final String introduction, final String university,
                                         final List<ProfileLinkRequest> profileLinkRequests) {
-        Member member = memberReader.findById(memberId);
-
         member.updateIntroduction(introduction);
         member.updateUniversity(university);
-        profileLinkWriter.deleteAllByMember(member);
+        memberWriter.save(member);
 
+        profileLinkWriter.deleteAllByMember(member);
         List<ProfileLink> profileLinks = profileLinkRequests.stream()
                 .map(lr -> ProfileLink.of(member, lr.linkType(), lr.link()))
                 .toList();

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/component/MemberWriter.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/component/MemberWriter.java
@@ -1,0 +1,18 @@
+package org.cotato.csquiz.domain.auth.service.component;
+
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.repository.MemberRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class MemberWriter {
+    private final MemberRepository memberRepository;
+
+    public void save(final Member member) {
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/component/ProfileLinkWriter.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/component/ProfileLinkWriter.java
@@ -1,0 +1,24 @@
+package org.cotato.csquiz.domain.auth.service.component;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.entity.ProfileLink;
+import org.cotato.csquiz.domain.auth.repository.ProfileLinkRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ProfileLinkWriter {
+    private final ProfileLinkRepository profileLinkRepository;
+
+    public void deleteAllByMember(final Member member) {
+        profileLinkRepository.deleteAllByMember(member);
+    }
+
+    public void createProfileLinks(List<ProfileLink> profileLinks) {
+        profileLinkRepository.saveAll(profileLinks);
+    }
+}


### PR DESCRIPTION
### Motivation
프로필 카드 내 멤버 정보 및 링크 추가

### Modification
구현했습니다


### Result
[<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
(지라 링크)](https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-124&text=%ED%94%84%EB%A1%9C%ED%95%84)

### Test (option)
![image](https://github.com/user-attachments/assets/24d9b1c6-0f22-49e8-b7e6-e7670d4b5daa)

1. 프로필 링크 엔티티
![image](https://github.com/user-attachments/assets/012838e2-b1e3-4818-8b38-870a464c1ed2)

2. 멤버 엔티티 
![image](https://github.com/user-attachments/assets/4683b16b-a2e5-488b-8c28-6fcc4463b4d0)


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->
프로필링크 테이블에 url 항목 추가
```
ALTER TABLE profile_link
ADD COLUMN url TEXT NOT NULL;
```
