### PR TITLE
[COT-130] Feature: 어노테이션을 통한 권한에 따른 API 접근 설정

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/config/WebConfig.java
+++ b/src/main/java/org/cotato/csquiz/common/config/WebConfig.java
@@ -1,8 +1,8 @@
 package org.cotato.csquiz.common.config;
 
 import lombok.RequiredArgsConstructor;
-import org.cotato.csquiz.common.idempotency.IdempotencyInterceptor;
 import org.cotato.csquiz.common.idempotency.IdempotencyRedisRepository;
+import org.cotato.csquiz.common.role.RoleInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -15,6 +15,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new RoleInterceptor())
+                .addPathPatterns("/**")
+                .order(1);
 //        registry.addInterceptor(new IdempotencyInterceptor(idempotencyRedisRepository))
 //                .addPathPatterns("/v1/api/record/reply")
 //                .order(1);

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
+    NO_PERMISSION_EXCEPTION(HttpStatus.FORBIDDEN, "NP-001", "권한이 없는 유저입니다."),
+
     // Auth 일반적인 인증 문제 Auth JWT 토큰 관련 에러
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "T-001", "이미 만료된 토큰입니다."),
     FILTER_EXCEPTION(HttpStatus.UNAUTHORIZED, "T-002", "필터 내부에러 발생"),
@@ -109,7 +111,7 @@ public enum ErrorCode {
     CHANNEL_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "S-011", "디스코드 채널을 찾지 못했습니다."),
     DISCORD_BUTTON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-012" , "디스코드 버튼 이벤트 ID를 찾지 못했습니다."),
     EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-013", "이메일 전송에 실패했습니다."),
-    FILE_GENERATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-014", "엑셀 파일 생성에 실패했습니다.")
+    FILE_GENERATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-014", "엑셀 파일 생성에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/cotato/csquiz/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/cotato/csquiz/common/error/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.sql.SQLException;
 import java.util.List;
+import javax.naming.NoPermissionException;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
@@ -92,5 +93,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.IMAGE_PROCESSING_FAIL, request);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    @ExceptionHandler(NoPermissionException.class)
+    public ResponseEntity<ErrorResponse> handleNoPermissionException(NoPermissionException e, HttpServletRequest request){
+        log.error("No Permission Error occurred");
+        log.error("Error Method and Path {}, {}", request.getMethod(), request.getRequestURI());
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NO_PERMISSION_EXCEPTION, request);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/role/RoleAuthority.java
+++ b/src/main/java/org/cotato/csquiz/common/role/RoleAuthority.java
@@ -1,0 +1,13 @@
+package org.cotato.csquiz.common.role;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.cotato.csquiz.domain.auth.enums.MemberRole;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RoleAuthority {
+    MemberRole value();
+}

--- a/src/main/java/org/cotato/csquiz/common/role/RoleInterceptor.java
+++ b/src/main/java/org/cotato/csquiz/common/role/RoleInterceptor.java
@@ -1,0 +1,43 @@
+package org.cotato.csquiz.common.role;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import javax.naming.NoPermissionException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.enums.MemberRole;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoleInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+        if (!handlerMethod.hasMethodAnnotation(RoleAuthority.class)) {
+            return true;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Member member = (Member) authentication.getPrincipal();
+
+        RoleAuthority methodAnnotation = handlerMethod.getMethodAnnotation(RoleAuthority.class);
+        MemberRole role = methodAnnotation.value();
+
+        if (role.ordinal() > member.getRole().ordinal()) {
+            throw new NoPermissionException("cannot process this method with role " + member.getRole());
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/role/RoleInterceptor.java
+++ b/src/main/java/org/cotato/csquiz/common/role/RoleInterceptor.java
@@ -32,9 +32,9 @@ public class RoleInterceptor implements HandlerInterceptor {
         Member member = (Member) authentication.getPrincipal();
 
         RoleAuthority methodAnnotation = handlerMethod.getMethodAnnotation(RoleAuthority.class);
-        MemberRole role = methodAnnotation.value();
+        MemberRole minimumRole = methodAnnotation.value();
 
-        if (role.ordinal() > member.getRole().ordinal()) {
+        if (minimumRole.isLower(member.getRole())) {
             throw new NoPermissionException("cannot process this method with role " + member.getRole());
         }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/enums/MemberRole.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/enums/MemberRole.java
@@ -1,32 +1,30 @@
 package org.cotato.csquiz.domain.auth.enums;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.cotato.csquiz.common.error.ErrorCode;
-import org.cotato.csquiz.common.error.exception.AppException;
 
 @Getter
 @RequiredArgsConstructor
 public enum MemberRole {
 
-    REFUSED("ROLE_REFUSED", "승인 거절 부원"),
-    GENERAL("ROLE_GENERAL", "승인 대기 부원"),
-    MEMBER("ROLE_MEMBER", "현재 활동 중인 부원"),
-    OLD_MEMBER("ROLE_OM", "활동 후 종료한 부원"),
-    EDUCATION("ROLE_EDUCATION","교육팀"),
-    OPERATION("ROLE_OPERATION", "운영지원팀"),
-    ADMIN("ROLE_ADMIN", "운영진");
+    REFUSED("ROLE_REFUSED", "승인 거절 부원", 6),
+    GENERAL("ROLE_GENERAL", "승인 대기 부원", 5),
+    OLD_MEMBER("ROLE_OM", "활동 후 종료한 부원", 4),
+    MEMBER("ROLE_MEMBER", "현재 활동 중인 부원", 3),
+    EDUCATION("ROLE_EDUCATION", "교육팀", 2),
+    OPERATION("ROLE_OPERATION", "운영지원팀", 2),
+    ADMIN("ROLE_ADMIN", "운영진", 1);
 
     private static final Map<String, MemberRole> ROLE_KEY_MAP = Stream.of(values())
             .collect(Collectors.toUnmodifiableMap(MemberRole::getKey, Function.identity()));
 
     private final String key;
     private final String description;
+    private final int priority;
 
     public static MemberRole fromKey(final String key) {
         MemberRole result = ROLE_KEY_MAP.get(key);
@@ -34,5 +32,9 @@ public enum MemberRole {
             throw new IllegalArgumentException(String.format("요청한 key(%s)를 찾을 수 없습니다.", key));
         }
         return result;
+    }
+
+    public boolean isLower(MemberRole role) {
+        return this.priority > role.priority;
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/enums/MemberRole.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/enums/MemberRole.java
@@ -18,9 +18,9 @@ public enum MemberRole {
     GENERAL("ROLE_GENERAL", "승인 대기 부원"),
     MEMBER("ROLE_MEMBER", "현재 활동 중인 부원"),
     OLD_MEMBER("ROLE_OM", "활동 후 종료한 부원"),
-    ADMIN("ROLE_ADMIN", "운영진"),
     EDUCATION("ROLE_EDUCATION","교육팀"),
-    OPERATION("ROLE_OPERATION", "운영지원팀");
+    OPERATION("ROLE_OPERATION", "운영지원팀"),
+    ADMIN("ROLE_ADMIN", "운영진");
 
     private static final Map<String, MemberRole> ROLE_KEY_MAP = Stream.of(values())
             .collect(Collectors.toUnmodifiableMap(MemberRole::getKey, Function.identity()));


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

현재 Security Config 파일을 통해 API 접근 권한을 관리하고 있다.
하지만 해당 방식은 아래와 같은 2가지 문제가 있다.

1. 파일이 매우 복잡하고 어지럽다.
2. 어플리케이션 로직이 변화에 따라 맞게 수정하기가 어렵다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

따라서, Controller에 어노테이션을 커스텀하고, 인터셉터에서 해당 역할과의 우선 순위를 비교해 처리한다.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-130&sprints=5

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->