### PR TITLE
[COT-136] Feature: DEV팀 역할 추가 및 권한 체크를 통한 활동 기수만 출결 + 문제 풀이 허용

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/record/controller/RecordController.java
+++ b/src/main/java/org/cotato/csquiz/api/record/controller/RecordController.java
@@ -8,9 +8,11 @@ import org.cotato.csquiz.api.record.dto.RegradeRequest;
 import org.cotato.csquiz.api.record.dto.ReplyRequest;
 import org.cotato.csquiz.api.record.dto.ReplyResponse;
 import org.cotato.csquiz.common.role.RoleAuthority;
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.MemberRole;
 import org.cotato.csquiz.domain.education.service.RecordService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,9 +29,9 @@ public class RecordController {
     private final RecordService recordService;
 
     @PostMapping("/reply")
-    public ResponseEntity<ReplyResponse> replyToQuiz(@RequestBody @Valid ReplyRequest request) {
+    public ResponseEntity<ReplyResponse> replyToQuiz(@AuthenticationPrincipal Member member, @RequestBody @Valid ReplyRequest request) {
         log.info("정답 제출 컨트롤러, 제출한 정답 : {}", request.inputs());
-        return ResponseEntity.ok().body(recordService.replyToQuiz(request));
+        return ResponseEntity.ok().body(recordService.replyToQuiz(request, member));
     }
 
     @RoleAuthority(MemberRole.MANAGER)

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     NO_PERMISSION_EXCEPTION(HttpStatus.FORBIDDEN, "NP-001", "권한이 없는 유저입니다."),
+    CANNOT_ACCESS_OTHER_GENERATION(HttpStatus.FORBIDDEN, "NP-002", "해당 기수의 부원이 아닙니다."),
 
     // Auth 일반적인 인증 문제 Auth JWT 토큰 관련 에러
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "T-001", "이미 만료된 토큰입니다."),
@@ -91,7 +92,6 @@ public enum ErrorCode {
     INVALID_RECORD_UPDATE(HttpStatus.BAD_REQUEST, "AT-105", "세션 타입에 맞게 출결 기록을 수정해주세요."),
     ALREADY_ATTEND(HttpStatus.CONFLICT, "AT-301", "이미 해당 타입으로 출석한 기록이 있습니다."),
     ATTENDANCE_NOT_OPEN(HttpStatus.BAD_REQUEST, "AT-401", "출석 시간이 아닙니다."),
-    ATTENDANCE_PERMISSION(HttpStatus.BAD_REQUEST, "AT-402", "해당 기수의 부원이 아닙니다."),
 
     //프로젝트 관련
     LOGO_IMAGE_EXIST(HttpStatus.CONFLICT, "PJ-301", "이미 로고 이미지가 존재합니다."),

--- a/src/main/java/org/cotato/csquiz/domain/auth/component/GenerationMemberAuthValidator.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/component/GenerationMemberAuthValidator.java
@@ -24,7 +24,7 @@ public class GenerationMemberAuthValidator {
 
     private void checkIsGenerationMember(Member member, Generation generation) {
         if (!generationMemberRepository.existsByGenerationAndMember(generation, member)) {
-            throw new AppException(ErrorCode.ATTENDANCE_PERMISSION);
+            throw new AppException(ErrorCode.CANNOT_ACCESS_OTHER_GENERATION);
         }
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/component/GenerationMemberAuthValidator.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/component/GenerationMemberAuthValidator.java
@@ -1,0 +1,30 @@
+package org.cotato.csquiz.domain.auth.component;
+
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.generation.entity.Generation;
+import org.cotato.csquiz.domain.generation.repository.GenerationMemberRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GenerationMemberAuthValidator {
+
+    private final GenerationMemberRepository generationMemberRepository;
+
+    public void checkGenerationPermission(final Member member, final Generation generation) {
+        if (member.isDevTeam()) {
+            return;
+        }
+
+        checkIsGenerationMember(member, generation);
+    }
+
+    private void checkIsGenerationMember(Member member, Generation generation) {
+        if (!generationMemberRepository.existsByGenerationAndMember(generation, member)) {
+            throw new AppException(ErrorCode.ATTENDANCE_PERMISSION);
+        }
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/entity/Member.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/entity/Member.java
@@ -133,4 +133,8 @@ public class Member extends BaseTimeEntity {
     public boolean isRejectedMember() {
         return this.status == MemberStatus.REJECTED;
     }
+
+    public boolean isDevTeam(){
+        return this.role == MemberRole.DEV;
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/enums/MemberRole.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/enums/MemberRole.java
@@ -13,7 +13,8 @@ public enum MemberRole {
 
     MEMBER("ROLE_MEMBER", "현재 활동 중인 부원", 1),
     MANAGER("ROLE_MANAGER", "운영 팀으로 활동하는 부원, 현재 교육팀과 운영지원팀", 2),
-    ADMIN("ROLE_ADMIN", "운영진", 3);
+    ADMIN("ROLE_ADMIN", "운영진", 3),
+    DEV("ROLE_DEV", "코테이토 개발팀", 4);
 
     private static final Map<String, MemberRole> ROLE_KEY_MAP = Stream.of(values())
             .collect(Collectors.toUnmodifiableMap(MemberRole::getKey, Function.identity()));


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

OM이 Member 역할을 받게 되면서 OM이 사용하지 못하는 기능인 출결과 문제 풀이를 진행할 수 있다.
이에 대한 권한을 제한해야한다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

출결과 문제 풀이 액션을 하기 이전에 GenerationMember 테이블에 값이 있는지 확인한다.
단, 개발팀은 모든 역할에 접근이 가능해야하니 허용하는 AuthValidator를 추가한다.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

resolve: https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-136&sprints=5

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->