### PR TITLE
[COT-153] Feature: 인증 필터의 Member를 명시적으로 저장한다

### DIFF
--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -59,6 +59,7 @@ public class MemberService {
         validateIsSameBefore(member.getPassword(), password);
 
         member.updatePassword(bCryptPasswordEncoder.encode(password));
+        memberRepository.save(member);
     }
 
     private void validateIsSameBefore(String originPassword, String newPassword) {
@@ -71,6 +72,7 @@ public class MemberService {
     public void updatePhoneNumber(final Member member, String phoneNumber) {
         String encryptedPhoneNumber = encryptService.encryptPhoneNumber(phoneNumber);
         member.updatePhoneNumber(encryptedPhoneNumber);
+        memberRepository.save(member);
     }
 
     @Transactional
@@ -85,6 +87,7 @@ public class MemberService {
 
         S3Info s3Info = s3Uploader.uploadFiles(image, PROFILE_BUCKET_DIRECTORY);
         member.updateProfileImage(s3Info);
+        memberRepository.save(member);
     }
 
     @Transactional
@@ -94,6 +97,7 @@ public class MemberService {
         }
 
         member.updateProfileImage(null);
+        memberRepository.save(member);
     }
 
     public MemberMyPageInfoResponse findMyPageInfo(Long memberId) {


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

`@AuthenticationPrincipal` 로 필터에서 인증한 부원을 가져오면 이는 영속성 컨텍스트에 존재하지 않아 update를 해도 값이 반영되지 않는다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

명시적으로 save를 날려주자

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-153&sprints=9

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->