### PR TITLE
[COT-160] Hotfix: 회원가입한 부원이 로그인 되지 않는 이슈

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/config/auth/PrincipalDetails.java
+++ b/src/main/java/org/cotato/csquiz/common/config/auth/PrincipalDetails.java
@@ -4,12 +4,15 @@ import java.util.Collection;
 import java.util.List;
 import lombok.Data;
 import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.enums.MemberRole;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Data
 public class PrincipalDetails implements UserDetails {
+
+    private static final String BASE_ROLE = "ROLE_BASE";
 
     private Member member;
 
@@ -19,7 +22,11 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(member.getRole().getKey()));
+        MemberRole role = member.getRole();
+        if (role == null) {
+            return List.of(new SimpleGrantedAuthority(BASE_ROLE));
+        }
+        return List.of(new SimpleGrantedAuthority(role.getKey()));
     }
 
     @Override

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthenticationFilter.java
@@ -39,7 +39,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             Member member = mapper.readValue(request.getInputStream(), Member.class);
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
                     member.getEmail(), member.getPassword());
-            log.info("member <{}> , password <{}>", member.getEmail(), member.getPassword());
             return authenticationManager.authenticate(authenticationToken);
         } catch (Exception e) {
             log.error("로그인 에러 발생 : <{}>", e.getMessage());

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthenticationFilter.java
@@ -39,8 +39,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             Member member = mapper.readValue(request.getInputStream(), Member.class);
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
                     member.getEmail(), member.getPassword());
+            log.info("member <{}> , password <{}>", member.getEmail(), member.getPassword());
             return authenticationManager.authenticate(authenticationToken);
         } catch (Exception e) {
+            e.printStackTrace();
             throw new FilterAuthenticationException("로그인 시도에 실패했습니다.");
         }
     }

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthenticationFilter.java
@@ -42,7 +42,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             log.info("member <{}> , password <{}>", member.getEmail(), member.getPassword());
             return authenticationManager.authenticate(authenticationToken);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("로그인 에러 발생 : <{}>", e.getMessage());
             throw new FilterAuthenticationException("로그인 시도에 실패했습니다.");
         }
     }

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
@@ -83,4 +83,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         AntPathMatcher pathMatcher = new AntPathMatcher();
         return pathMatcher.match(AUTH_PATH, requestURI) || pathMatcher.match(LOGIN_PATH, requestURI);
     }
+
+    public static void main(String[] args) {
+        AntPathMatcher pathMatcher = new AntPathMatcher();
+        System.out.println(pathMatcher.match(AUTH_PATH, "/v1/api/auth/join"));
+    }
 }


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

최초 회원가입한 유저가 로그인이 되지 않는다.
이유는 부원 역할 변경을 진행하며 member_role 필드를 null로 설정했는데 이게 PrincipalDetail getAuthorities 설정 시 에러를 발생함
원인은 member_role이 Null이기 때문

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

ROLE_역할이름 이 붙은 형태이면 무관하므로 ROLE_BASE로 기본 설정을 하자.
null로 설정 시 에러가 발생함.

다만, 이제 역할에 따른 세부 설정은 security 에서 진행하지 않는데, Security 기반 로그인이 필요할까 싶다.
하지만, 하위호환성을 고려해 일단은 skip..

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

resolve: https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-160&sprints=13

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->