### PR TITLE
[COT-156] Feature: GenerationMember에 추가 가능한 멤버 리스트 반환 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,16 @@ repositories {
     mavenCentral()
 }
 
+def generated = 'src/main/generated'
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -52,6 +62,12 @@ dependencies {
     // Apache POI 관련
     implementation 'org.apache.poi:poi:5.2.3'
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
+
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.0.0"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package org.cotato.csquiz.api.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import javax.naming.NoPermissionException;
@@ -20,6 +21,7 @@ import org.cotato.csquiz.domain.auth.service.MemberService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -45,13 +47,14 @@ public class MemberController {
         return ResponseEntity.ok().body(memberService.findMemberInfo(member));
     }
 
+    @Operation(summary = "기수별 멤버에 추가 가능한 멤버 반환 API")
     @RoleAuthority(MemberRole.ADMIN)
     @GetMapping
     public ResponseEntity<AddableMembersResponse> findAddableMembersForGenerationMember(
-            @RequestParam(name = "generationId") Long generationId,
-            @RequestParam(name = "passedGenerationNumber", required = false) Integer generationNumber,
-            @RequestParam(name = "memberPosition", required = false) MemberPosition memberPosition,
-            @RequestParam(name = "name", required = false) String name
+            @RequestParam(name = "generationId") @Parameter(description = "추가하고 싶은 기수의 Id") Long generationId,
+            @RequestParam(name = "passedGenerationNumber", required = false) @Parameter(description = "멤버 합격 기수") Integer generationNumber,
+            @RequestParam(name = "memberPosition", required = false) @Parameter(description = "멤버 포지션") MemberPosition memberPosition,
+            @RequestParam(name = "name", required = false) @Parameter(description = "멤버 이름") String name
     ) {
         return ResponseEntity.ok()
                 .body(memberService.findAddableMembers(generationId, generationNumber, memberPosition, name));

--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -7,11 +7,15 @@ import javax.naming.NoPermissionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.api.admin.dto.MemberInfoResponse;
+import org.cotato.csquiz.api.member.dto.AddableMembersResponse;
 import org.cotato.csquiz.api.member.dto.MemberMyPageInfoResponse;
 import org.cotato.csquiz.api.member.dto.UpdatePasswordRequest;
 import org.cotato.csquiz.api.member.dto.UpdatePhoneNumberRequest;
 import org.cotato.csquiz.api.member.dto.UpdateProfileInfoRequest;
+import org.cotato.csquiz.common.role.RoleAuthority;
 import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.enums.MemberPosition;
+import org.cotato.csquiz.domain.auth.enums.MemberRole;
 import org.cotato.csquiz.domain.auth.service.MemberService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -38,6 +43,18 @@ public class MemberController {
     public ResponseEntity<MemberInfoResponse> findMemberInfo(
             @AuthenticationPrincipal Member member) {
         return ResponseEntity.ok().body(memberService.findMemberInfo(member));
+    }
+
+    @RoleAuthority(MemberRole.ADMIN)
+    @GetMapping
+    public ResponseEntity<AddableMembersResponse> findAddableMembersForGenerationMember(
+            @RequestParam(name = "generationId") Long generationId,
+            @RequestParam(name = "passedGenerationNumber", required = false) Integer generationNumber,
+            @RequestParam(name = "memberPosition", required = false) MemberPosition memberPosition,
+            @RequestParam(name = "name", required = false) String name
+    ) {
+        return ResponseEntity.ok()
+                .body(memberService.findAddableMembers(generationId, generationNumber, memberPosition, name));
     }
 
     @PatchMapping("/update/password")

--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -53,11 +53,11 @@ public class MemberController {
     public ResponseEntity<AddableMembersResponse> findAddableMembersForGenerationMember(
             @RequestParam(name = "generationId") @Parameter(description = "추가하고 싶은 기수의 Id") Long generationId,
             @RequestParam(name = "passedGenerationNumber", required = false) @Parameter(description = "멤버 합격 기수") Integer generationNumber,
-            @RequestParam(name = "memberPosition", required = false) @Parameter(description = "멤버 포지션") MemberPosition memberPosition,
+            @RequestParam(name = "position", required = false) @Parameter(description = "멤버 포지션") MemberPosition position,
             @RequestParam(name = "name", required = false) @Parameter(description = "멤버 이름") String name
     ) {
         return ResponseEntity.ok()
-                .body(memberService.findAddableMembers(generationId, generationNumber, memberPosition, name));
+                .body(memberService.findAddableMembers(generationId, generationNumber, position, name));
     }
 
     @PatchMapping("/update/password")

--- a/src/main/java/org/cotato/csquiz/api/member/dto/AddableMemberInfo.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/AddableMemberInfo.java
@@ -1,12 +1,17 @@
 package org.cotato.csquiz.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.MemberPosition;
 
 public record AddableMemberInfo(
+        @Schema(description = "멤버 Id")
         Long memberId,
+        @Schema(description = "이름")
         String name,
+        @Schema(description = "합격 기수")
         Integer generationNumber,
+        @Schema(description = "포지션")
         MemberPosition memberPosition
 ) {
     public static AddableMemberInfo from(Member member) {

--- a/src/main/java/org/cotato/csquiz/api/member/dto/AddableMemberInfo.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/AddableMemberInfo.java
@@ -1,18 +1,19 @@
 package org.cotato.csquiz.api.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.MemberPosition;
 
 public record AddableMemberInfo(
-        @Schema(description = "멤버 Id")
+        @Schema(description = "멤버 Id", requiredMode = RequiredMode.REQUIRED)
         Long memberId,
-        @Schema(description = "이름")
+        @Schema(description = "이름", requiredMode = RequiredMode.REQUIRED)
         String name,
-        @Schema(description = "합격 기수")
+        @Schema(description = "합격 기수", requiredMode = RequiredMode.REQUIRED)
         Integer generationNumber,
-        @Schema(description = "포지션")
-        MemberPosition memberPosition
+        @Schema(description = "포지션", requiredMode = RequiredMode.REQUIRED)
+        MemberPosition position
 ) {
     public static AddableMemberInfo from(Member member) {
         return new AddableMemberInfo(member.getId(),

--- a/src/main/java/org/cotato/csquiz/api/member/dto/AddableMemberInfo.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/AddableMemberInfo.java
@@ -1,0 +1,18 @@
+package org.cotato.csquiz.api.member.dto;
+
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.enums.MemberPosition;
+
+public record AddableMemberInfo(
+        Long memberId,
+        String name,
+        Integer generationNumber,
+        MemberPosition memberPosition
+) {
+    public static AddableMemberInfo from(Member member) {
+        return new AddableMemberInfo(member.getId(),
+                member.getName(),
+                member.getPassedGenerationNumber(),
+                member.getPosition());
+    }
+}

--- a/src/main/java/org/cotato/csquiz/api/member/dto/AddableMembersResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/AddableMembersResponse.java
@@ -1,0 +1,14 @@
+package org.cotato.csquiz.api.member.dto;
+
+import java.util.List;
+import org.cotato.csquiz.domain.auth.entity.Member;
+
+public record AddableMembersResponse(
+        List<AddableMemberInfo> memberInfos
+) {
+    public static AddableMembersResponse from(List<Member> members) {
+        return new AddableMembersResponse(members.stream()
+                .map(AddableMemberInfo::from)
+                .toList());
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/config/JpaConfig.java
+++ b/src/main/java/org/cotato/csquiz/common/config/JpaConfig.java
@@ -1,9 +1,20 @@
 package org.cotato.csquiz.common.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/entity/Member.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/entity/Member.java
@@ -134,6 +134,14 @@ public class Member extends BaseTimeEntity {
         return this.status == MemberStatus.REJECTED;
     }
 
+    public boolean isApproved() {
+        return this.status == MemberStatus.APPROVED;
+    }
+
+    public boolean isRetired() {
+        return this.status == MemberStatus.RETIRED;
+    }
+
     public boolean isDevTeam(){
         return this.role == MemberRole.DEV;
     }

--- a/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByPhoneNumber(String phone);

--- a/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepositoryCustom.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.cotato.csquiz.domain.auth.repository;
+
+import java.util.List;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.enums.MemberPosition;
+
+public interface MemberRepositoryCustom {
+    List<Member> findAllWithFilters(Integer passedGenerationNumber, MemberPosition memberPosition, String name);
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepositoryCustomImpl.java
@@ -3,14 +3,14 @@ package org.cotato.csquiz.domain.auth.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.entity.QMember;
 import org.cotato.csquiz.domain.auth.enums.MemberPosition;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class MemberRepositoryCustomImpl  implements MemberRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepositoryCustomImpl.java
@@ -2,23 +2,17 @@ package org.cotato.csquiz.domain.auth.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.entity.QMember;
 import org.cotato.csquiz.domain.auth.enums.MemberPosition;
-import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implements MemberRepositoryCustom {
-
+@AllArgsConstructor
+public class MemberRepositoryCustomImpl  implements MemberRepositoryCustom {
     private final JPAQueryFactory queryFactory;
-
-    public MemberRepositoryCustomImpl(EntityManager em) {
-        super(Member.class);
-        this.queryFactory = new JPAQueryFactory(em);
-    }
 
     @Override
     public List<Member> findAllWithFilters(Integer passedGenerationNumber, MemberPosition memberPosition, String name) {

--- a/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,44 @@
+package org.cotato.csquiz.domain.auth.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.entity.QMember;
+import org.cotato.csquiz.domain.auth.enums.MemberPosition;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MemberRepositoryCustomImpl(EntityManager em) {
+        super(Member.class);
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<Member> findAllWithFilters(Integer passedGenerationNumber, MemberPosition memberPosition, String name) {
+        QMember qMember = QMember.member;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (passedGenerationNumber != null) {
+            builder.and(qMember.passedGenerationNumber.eq(passedGenerationNumber));
+        }
+
+        if (memberPosition != null) {
+            builder.and(qMember.position.eq(memberPosition));
+        }
+
+        if (name != null && !name.isEmpty()) {
+            builder.and(qMember.name.containsIgnoreCase(name));
+        }
+
+        return queryFactory.selectFrom(qMember)
+                .where(builder)
+                .fetch();
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -138,7 +138,7 @@ public class MemberService {
 
         List<Member> filteredAddableMember = memberRepository.findAllWithFilters(generationNumber, memberPosition, name)
                 .stream()
-                .filter(this::isApprovedOrOM)
+                .filter(member -> member.isApproved() || member.isRetired())
                 .filter(member -> !existMemberIds.contains(member.getId()))
                 .sorted(Comparator
                         .comparing(Member::isApproved)
@@ -147,9 +147,5 @@ public class MemberService {
                 )
                 .toList();
         return AddableMembersResponse.from(filteredAddableMember);
-    }
-
-    private boolean isApprovedOrOM(Member member) {
-        return member.isApproved() || member.isRetired();
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/repository/GenerationMemberRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/repository/GenerationMemberRepository.java
@@ -16,6 +16,7 @@ public interface GenerationMemberRepository extends JpaRepository<GenerationMemb
     @Query("select gm from GenerationMember gm join fetch gm.member m where gm.generation = :generation")
     List<GenerationMember> findAllByGenerationWithMember(@Param("generation") Generation generation);
 
+    @Transactional(readOnly = true)
     @Query("select gm from GenerationMember gm join fetch gm.member m where gm.generation.id = :generationId")
     List<GenerationMember> findAllByGenerationIdWithMember(@Param("generationId") Long generationId);
 

--- a/src/main/java/org/cotato/csquiz/domain/generation/repository/GenerationMemberRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/repository/GenerationMemberRepository.java
@@ -16,6 +16,9 @@ public interface GenerationMemberRepository extends JpaRepository<GenerationMemb
     @Query("select gm from GenerationMember gm join fetch gm.member m where gm.generation = :generation")
     List<GenerationMember> findAllByGenerationWithMember(@Param("generation") Generation generation);
 
+    @Query("select gm from GenerationMember gm join fetch gm.member m where gm.generation.id = :generationId")
+    List<GenerationMember> findAllByGenerationIdWithMember(@Param("generationId") Long generationId);
+
     @Transactional
     @Modifying
     @Query("delete from GenerationMember g where g.id in :ids")


### PR DESCRIPTION
### Motivation
기수별 부원 목록 추가 시 가능한 멤버 목록을 반환하는 API를 통해 등록 가능한 멤버 리스트를 반환한다.

### Modification
필터링하는 기준은 다음과 같다.
- 해당 기수에 이미 들어가 있는 멤버는 제외(필수)
- OM과 활동 부원(필수)
- 기수(선택)
- 포지션(선택)
- 이름(선택)

각 필터를 적용하는 방법을 다음과 같다.
- OM과 활동 부원(필수)
    - MemberStatus.java에 해당 부분이 있다.
            
        ```
        REJECTED("가입 신청 후 거절된 부원"),
        REQUESTED("최초 가입 신청한 대기 상태의 부원"),
        RETIRED("수료 후 활동을 종료한 부원"),
        APPROVED("가입 신청 후 승인된 부원")
        ;
        ```
        
        RETIRED와 APPROVED 항목을 가져온다. 
- 해당 기수에 이미 들어가 있는 멤버는 제외(필수)
    - 기수(generationId) 를 param으로 받아 generationMember의 memberId 리스트를 만든다.
    - 활동 + OM 멤버의 memberId가 리스트 존재한다면 거른다

        
- 기수, 포지션, 이름(선택)
    - QueryDsl을 통해 동적으로 필터링한다.
    

### 정렬 기준
- 활동 부원(MemberStatus.APPROVED)가 먼저 나오고 OM이 나온다.
- 이후 이름 순으로 정렬

### Result
https://youthing.atlassian.net/jira/software/projects/COT/boards/2/backlog?selectedIssue=COT-156

### Test (option)
![image](https://github.com/user-attachments/assets/c8b3cca3-f0b0-4a4e-8efb-335dee1a998a)

![image](https://github.com/user-attachments/assets/a5f609e1-8b87-45db-9d4b-59f285d3ab32)



### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->