### PR TITLE
[COT-166] Feature: 회원 탈퇴 정책 조회 API 구현

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/policy/controller/PolicyController.java
+++ b/src/main/java/org/cotato/csquiz/api/policy/controller/PolicyController.java
@@ -1,6 +1,7 @@
 package org.cotato.csquiz.api.policy.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.cotato.csquiz.api.policy.dto.CheckMemberPoliciesRequest;
 import org.cotato.csquiz.api.policy.dto.FindMemberPolicyResponse;
 import org.cotato.csquiz.api.policy.dto.PoliciesResponse;
 import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.enums.PolicyCategory;
 import org.cotato.csquiz.domain.auth.service.PolicyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "회원 정책 API")
@@ -39,9 +42,16 @@ public class PolicyController {
         return ResponseEntity.noContent().build();
     }
 
+    @Deprecated(since = "회원 탈퇴 기능 작업 이후")
     @Operation(summary = "회원 가입 시 보여줘야 할 정책 목록 반환 API")
     @GetMapping
     public ResponseEntity<PoliciesResponse> getPolicies() {
         return ResponseEntity.ok().body(policyService.findPolicies());
+    }
+
+    @Operation(summary = "특정 카테고리에 맞는 정책 목록 반환 API")
+    @GetMapping(params = "category")
+    public ResponseEntity<PoliciesResponse> getPolicies(@RequestParam PolicyCategory category) {
+        return ResponseEntity.ok().body(policyService.findPolicies(category));
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/entity/Policy.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/entity/Policy.java
@@ -11,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cotato.csquiz.common.entity.BaseTimeEntity;
+import org.cotato.csquiz.domain.auth.enums.PolicyCategory;
 import org.cotato.csquiz.domain.auth.enums.PolicyType;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
@@ -30,6 +31,10 @@ public class Policy extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @ColumnDefault(value = "'ESSENTIAL'")
     private PolicyType policyType;
+
+    @Column(name = "policy_category", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PolicyCategory category;
 
     @Column(name = "policy_title", nullable = false)
     private String title;

--- a/src/main/java/org/cotato/csquiz/domain/auth/enums/PolicyCategory.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/enums/PolicyCategory.java
@@ -1,0 +1,14 @@
+package org.cotato.csquiz.domain.auth.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PolicyCategory {
+    PERSONAL_INFORMATION("개인정보 관련된 정책"),
+    LEAVING("회원 탈퇴 시 필요한 정책"),
+    ;
+
+    private final String description;
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/repository/PolicyRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/repository/PolicyRepository.java
@@ -2,6 +2,7 @@ package org.cotato.csquiz.domain.auth.repository;
 
 import java.util.List;
 import org.cotato.csquiz.domain.auth.entity.Policy;
+import org.cotato.csquiz.domain.auth.enums.PolicyCategory;
 import org.cotato.csquiz.domain.auth.enums.PolicyType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface PolicyRepository extends JpaRepository<Policy, Long> {
     List<Policy> findAllByPolicyType(PolicyType policyType);
 
     List<Policy> findAllByIdIn(List<Long> ids);
+
+    List<Policy> findAllByCategory(PolicyCategory category);
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/PolicyService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/PolicyService.java
@@ -14,6 +14,7 @@ import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.entity.MemberPolicy;
 import org.cotato.csquiz.domain.auth.entity.Policy;
+import org.cotato.csquiz.domain.auth.enums.PolicyCategory;
 import org.cotato.csquiz.domain.auth.enums.PolicyType;
 import org.cotato.csquiz.domain.auth.repository.MemberPolicyRepository;
 import org.cotato.csquiz.domain.auth.repository.PolicyRepository;
@@ -100,6 +101,13 @@ public class PolicyService {
 
     public PoliciesResponse findPolicies() {
         List<PolicyInfoResponse> policies = policyRepository.findAll().stream()
+                .map(PolicyInfoResponse::from)
+                .toList();
+        return new PoliciesResponse(policies);
+    }
+
+    public PoliciesResponse findPolicies(PolicyCategory category) {
+        List<PolicyInfoResponse> policies = policyRepository.findAllByCategory(category).stream()
                 .map(PolicyInfoResponse::from)
                 .toList();
         return new PoliciesResponse(policies);


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

회원 탈퇴 정책 조회 API를 구현한다.
이 때, 기존 정책과 구분이 필요하다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

현재 정책은 회원 가입 시에 조회하는 '개인 정보 보호' 정책이다.
'탈퇴' 관련 정책을 추가하자.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

resolve: https://youthing.atlassian.net/browse/COT-166

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->

```SQL
# category 컬럼 추가
ALTER TABLE policy
ADD COLUMN category VARCHAR(255) NOT NULL;

# 기존 정책에 개인정보 카테고리 추가

update policy set category = 'PERSONAL_INFORMATION' where policy_id in (1, 2);

# 새로운 정책 추가 (기획팀과 논의중)

```

