### PR TITLE
[COT-168] Feature: 기수별 멤버 역할 필드 타입 변경

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/member/dto/GenerationMemberInfo.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/GenerationMemberInfo.java
@@ -2,15 +2,15 @@ package org.cotato.csquiz.api.member.dto;
 
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.MemberPosition;
-import org.cotato.csquiz.domain.auth.enums.MemberRole;
 import org.cotato.csquiz.domain.generation.entity.GenerationMember;
+import org.cotato.csquiz.domain.generation.enums.GenerationMemberRole;
 
 public record GenerationMemberInfo(
         Long generationMemberId,
         String name,
         MemberPosition position,
         Integer generationNumber,
-        MemberRole role
+        GenerationMemberRole role
 ) {
     public static GenerationMemberInfo from(GenerationMember generationMember) {
         Member member = generationMember.getMember();

--- a/src/main/java/org/cotato/csquiz/api/member/dto/UpdateGenerationMemberRoleRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/UpdateGenerationMemberRoleRequest.java
@@ -1,12 +1,12 @@
 package org.cotato.csquiz.api.member.dto;
 
 import jakarta.validation.constraints.NotNull;
-import org.cotato.csquiz.domain.auth.enums.MemberRole;
+import org.cotato.csquiz.domain.generation.enums.GenerationMemberRole;
 
 public record UpdateGenerationMemberRoleRequest(
         @NotNull(message = "멤버별 활동 정보를 입력해주세요")
         Long generationMemberId,
         @NotNull(message = "역할을 입력해주세요")
-        MemberRole role
+        GenerationMemberRole role
 ) {
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/GenerationMemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/GenerationMemberService.java
@@ -9,11 +9,11 @@ import org.cotato.csquiz.api.member.dto.GenerationMemberInfoResponse;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.domain.auth.entity.Member;
-import org.cotato.csquiz.domain.auth.enums.MemberRole;
 import org.cotato.csquiz.domain.auth.service.component.GenerationMemberReader;
 import org.cotato.csquiz.domain.auth.service.component.MemberReader;
 import org.cotato.csquiz.domain.generation.entity.Generation;
 import org.cotato.csquiz.domain.generation.entity.GenerationMember;
+import org.cotato.csquiz.domain.generation.enums.GenerationMemberRole;
 import org.cotato.csquiz.domain.generation.repository.GenerationMemberRepository;
 import org.cotato.csquiz.domain.generation.service.component.GenerationReader;
 import org.springframework.stereotype.Service;
@@ -53,7 +53,7 @@ public class GenerationMemberService {
     }
 
     @Transactional
-    public void updateGenerationMemberRole(Long generationMemberId, MemberRole memberRole) {
+    public void updateGenerationMemberRole(Long generationMemberId, GenerationMemberRole memberRole) {
         GenerationMember generationMember = generationMemberReader.findById(generationMemberId);
         generationMember.updateMemberRole(memberRole);
     }

--- a/src/main/java/org/cotato/csquiz/domain/generation/entity/GenerationMember.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/entity/GenerationMember.java
@@ -15,7 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cotato.csquiz.common.entity.BaseTimeEntity;
 import org.cotato.csquiz.domain.auth.entity.Member;
-import org.cotato.csquiz.domain.auth.enums.MemberRole;
+import org.cotato.csquiz.domain.generation.enums.GenerationMemberRole;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -41,20 +41,20 @@ public class GenerationMember extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "role")
     @ColumnDefault(value = "'MEMBER'")
-    private MemberRole role = MemberRole.MEMBER;
+    private GenerationMemberRole role = GenerationMemberRole.MEMBER;
 
-    private GenerationMember(Generation generation, Member member, MemberRole role) {
+    private GenerationMember(Generation generation, Member member, GenerationMemberRole role) {
         this.generation = generation;
         this.member = member;
         this.role = role;
     }
 
     public static GenerationMember of(Generation generation, Member member) {
-        return new GenerationMember(generation, member, MemberRole.MEMBER);
+        return new GenerationMember(generation, member, GenerationMemberRole.MEMBER);
     }
 
-    public void updateMemberRole(MemberRole memberRole) {
-        this.role = memberRole;
+    public void updateMemberRole(GenerationMemberRole role) {
+        this.role = role;
     }
 
     public String getMemberName() {

--- a/src/main/java/org/cotato/csquiz/domain/generation/enums/GenerationMemberRole.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/enums/GenerationMemberRole.java
@@ -1,0 +1,18 @@
+package org.cotato.csquiz.domain.generation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GenerationMemberRole {
+    MEMBER("일반부원"),
+    LEADER_TEAM("회장단"),
+    OPERATION_SUPPORT_TEAM("운영지원팀"),
+    EDUCATION_TEAM("교육팀"),
+    PLANNING_TEAM("기획팀"),
+    MARKETING_TEAM("홍보팀"),
+    ;
+
+    private final String description;
+}


### PR DESCRIPTION
### Motivation
MemberRole enum 값이 변경됨에 따라 기수별 멤버 목록에 사용될 Enum 값이 추가되어야 한다.

### Modification
기존 MemberRole에서 GenerationMemberRole로 타입을 변경함


### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
기존과 컬럼명이 동일하기 때문에 임시 컬럼을 만들고 이전할 예정

```SQL
# 데이터 이전
UPDATE generation_member 
SET role = 'LEADER_TEAM' where role = 'ADMIN';

UPDATE generation_member 
SET role = 'EDUCATION_TEAM' where role = 'EDUCUATION';

**이 때 기존에 팀장들은 ADMIN이기 때문에 수동으로 각 팀으로 변경해줘야한다.**
```

