### PR TITLE
[COT-176] Hotfix: 교육과 연결된 세션 목록 접근 권한 해제

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/session/controller/SessionController.java
+++ b/src/main/java/org/cotato/csquiz/api/session/controller/SessionController.java
@@ -57,12 +57,10 @@ public class SessionController {
     }
 
     @Operation(summary = "CS ON인 세션 목록 반환 API", description = "세션과 교육 연계 제거 시 삭제 예정")
-    @RoleAuthority(MemberRole.MANAGER)
     @GetMapping("/cs-on")
     public ResponseEntity<List<CsEducationOnSessionNumberResponse>> findAllCsOnSessionsByGenerationId(
             @RequestParam Long generationId) {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(sessionService.findAllNotLinkedCsOnSessionsByGenerationId(generationId));
+        return ResponseEntity.status(HttpStatus.OK).body(sessionService.findAllNotLinkedCsOnSessionsByGenerationId(generationId));
     }
 
     @Operation(summary = "Session 추가 API")

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
@@ -84,9 +84,4 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         AntPathMatcher pathMatcher = new AntPathMatcher();
         return pathMatcher.match(AUTH_PATH, requestURI) || pathMatcher.match(LOGIN_PATH, requestURI);
     }
-
-    public static void main(String[] args) {
-        AntPathMatcher pathMatcher = new AntPathMatcher();
-        System.out.println(pathMatcher.match(AUTH_PATH, "/v1/api/auth/join"));
-    }
 }


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

교육과 연결된 세션 목록은 교육 추가 시에만 필요한 API라 Manager 권한이 부여됨
하지만, session 이하 GET 메서드는 인증을 진행하지 않음

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

- 모두에게 허용하자.
- 추후에 교육과 세션 연결 해제 시 삭제될 API임


### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->