### PR TITLE
[COT-187] Feature: 프로필 정보 반환 API

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -87,9 +87,9 @@ public class MemberController {
     }
 
     @Operation(summary = "멤버 프로필 정보 반환 API")
-    @GetMapping("/profile")
-    public ResponseEntity<ProfileInfoResponse> findProfileInfo(@AuthenticationPrincipal Member member) {
-        return ResponseEntity.ok(memberService.findMemberProfileInfo(member));
+    @GetMapping("/{memberId}/profile")
+    public ResponseEntity<ProfileInfoResponse> findProfileInfo(@PathVariable("memberId") Long memberId) {
+        return ResponseEntity.ok(memberService.findMemberProfileInfo(memberId));
     }
 
     @GetMapping("/{memberId}/mypage")

--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.api.admin.dto.MemberInfoResponse;
 import org.cotato.csquiz.api.member.dto.AddableMembersResponse;
 import org.cotato.csquiz.api.member.dto.MemberMyPageInfoResponse;
+import org.cotato.csquiz.api.member.dto.ProfileInfoResponse;
 import org.cotato.csquiz.api.member.dto.UpdatePasswordRequest;
 import org.cotato.csquiz.api.member.dto.UpdatePhoneNumberRequest;
 import org.cotato.csquiz.api.member.dto.UpdateProfileInfoRequest;
@@ -83,6 +84,12 @@ public class MemberController {
         memberService.updateMemberProfileInfo(member, request.introduction(), request.university(),
                 request.profileLinks(), profileImage);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "멤버 프로필 정보 반환 API")
+    @GetMapping("/profile")
+    public ResponseEntity<ProfileInfoResponse> findProfileInfo(@AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok(memberService.findMemberProfileInfo(member));
     }
 
     @GetMapping("/{memberId}/mypage")

--- a/src/main/java/org/cotato/csquiz/api/member/dto/MemberMyPageInfoResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/MemberMyPageInfoResponse.java
@@ -1,23 +1,18 @@
 package org.cotato.csquiz.api.member.dto;
 
-import org.cotato.csquiz.domain.auth.enums.MemberPosition;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import org.cotato.csquiz.domain.auth.entity.Member;
 
 public record MemberMyPageInfoResponse(
-        Long memberId,
+        @Schema(description = "이메일", requiredMode = RequiredMode.REQUIRED)
         String email,
-        String name,
-        Integer generationNumber,
-        MemberPosition position,
+        @Schema(description = "전화번호", requiredMode = RequiredMode.REQUIRED)
         String phoneNumber
 ) {
     public static MemberMyPageInfoResponse of(Member member, String originPhoneNumber) {
         return new MemberMyPageInfoResponse(
-                member.getId(),
                 member.getEmail(),
-                member.getName(),
-                member.getPassedGenerationNumber(),
-                member.getPosition(),
                 originPhoneNumber
         );
     }

--- a/src/main/java/org/cotato/csquiz/api/member/dto/MemberMyPageInfoResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/MemberMyPageInfoResponse.java
@@ -9,8 +9,7 @@ public record MemberMyPageInfoResponse(
         String name,
         Integer generationNumber,
         MemberPosition position,
-        String phoneNumber,
-        String profileImage
+        String phoneNumber
 ) {
     public static MemberMyPageInfoResponse of(Member member, String originPhoneNumber) {
         return new MemberMyPageInfoResponse(
@@ -19,8 +18,7 @@ public record MemberMyPageInfoResponse(
                 member.getName(),
                 member.getPassedGenerationNumber(),
                 member.getPosition(),
-                originPhoneNumber,
-                member.getProfileImageUrl()
+                originPhoneNumber
         );
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/member/dto/ProfileInfoResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/ProfileInfoResponse.java
@@ -1,0 +1,42 @@
+package org.cotato.csquiz.api.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.util.List;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.entity.ProfileLink;
+import org.cotato.csquiz.domain.auth.enums.MemberPosition;
+
+public record ProfileInfoResponse(
+        @Schema(description = "멤버 pk", requiredMode = RequiredMode.REQUIRED)
+        Long memberId,
+        @Schema(description = "멤버 이름", requiredMode = RequiredMode.REQUIRED)
+        String name,
+        @Schema(description = "합격 기수", requiredMode = RequiredMode.REQUIRED)
+        Integer generationNumber,
+        @Schema(description = "멤버 포지션", requiredMode = RequiredMode.REQUIRED)
+        MemberPosition position,
+        @Schema(description = "프로필 사진", requiredMode = RequiredMode.REQUIRED, nullable = true)
+        String profileImage,
+        @Schema(description = "자기 소개", requiredMode = RequiredMode.REQUIRED, nullable = true)
+        String introduction,
+        @Schema(description = "대학교", requiredMode = RequiredMode.REQUIRED, nullable = true)
+        String university,
+        @Schema(description = "프로필 링크", requiredMode = RequiredMode.REQUIRED)
+        List<ProfileLinkResponse> profileLinks
+) {
+    public static ProfileInfoResponse of(final Member member, final List<ProfileLink> profileLinks) {
+        return new ProfileInfoResponse(
+                member.getId(),
+                member.getName(),
+                member.getPassedGenerationNumber(),
+                member.getPosition(),
+                member.getProfileImageUrl(),
+                member.getIntroduction(),
+                member.getUniversity(),
+                profileLinks.stream()
+                        .map(ProfileLinkResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/cotato/csquiz/api/member/dto/ProfileLinkResponse.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/ProfileLinkResponse.java
@@ -1,0 +1,23 @@
+package org.cotato.csquiz.api.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import org.cotato.csquiz.domain.auth.entity.ProfileLink;
+import org.cotato.csquiz.domain.auth.enums.UrlType;
+
+public record ProfileLinkResponse(
+        @Schema(description = "링크 pk", requiredMode = RequiredMode.REQUIRED)
+        Long linkId,
+        @Schema(description = "링크 타입", requiredMode = RequiredMode.REQUIRED)
+        UrlType urlType,
+        @Schema(description = "링크 url", requiredMode = RequiredMode.REQUIRED)
+        String url
+) {
+    public static ProfileLinkResponse from(ProfileLink profileLink) {
+        return new ProfileLinkResponse(
+                profileLink.getId(),
+                profileLink.getUrlType(),
+                profileLink.getUrl()
+        );
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/repository/ProfileLinkRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/repository/ProfileLinkRepository.java
@@ -1,9 +1,12 @@
 package org.cotato.csquiz.domain.auth.repository;
 
+import java.util.List;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.entity.ProfileLink;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProfileLinkRepository extends JpaRepository<ProfileLink, Long> {
     void deleteAllByMember(Member member);
+
+    List<ProfileLink> findAllByMember(Member member);
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -82,7 +82,8 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public ProfileInfoResponse findMemberProfileInfo(final Member member) {
+    public ProfileInfoResponse findMemberProfileInfo(final Long memberId) {
+        Member member = memberReader.findById(memberId);
         List<ProfileLink> profileLinks = profileLinkRepository.findAllByMember(member);
         return ProfileInfoResponse.of(member, profileLinks);
     }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -10,6 +10,7 @@ import org.cotato.csquiz.api.admin.dto.MemberInfoResponse;
 import org.cotato.csquiz.api.member.dto.AddableMembersResponse;
 import org.cotato.csquiz.api.member.dto.MemberInfo;
 import org.cotato.csquiz.api.member.dto.MemberMyPageInfoResponse;
+import org.cotato.csquiz.api.member.dto.ProfileInfoResponse;
 import org.cotato.csquiz.api.member.dto.ProfileLinkRequest;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
@@ -79,6 +80,11 @@ public class MemberService {
         String encryptedPhoneNumber = encryptService.encryptPhoneNumber(phoneNumber);
         member.updatePhoneNumber(encryptedPhoneNumber);
         memberRepository.save(member);
+    }
+
+    public ProfileInfoResponse findMemberProfileInfo(final Member member) {
+        List<ProfileLink> profileLinks = profileLinkRepository.findAllByMember(member);
+        return ProfileInfoResponse.of(member, profileLinks);
     }
 
     @Transactional


### PR DESCRIPTION
### Motivation
- 프로필 카드 정보를 가져올 수 없어 API 구현

### Modification
- 프로필 카드에 필요한 정보를 반환하는 API 구현
- 마이페이지 정보 반환 시 프로필 사진 정보는 반환하지 않게 변경

고민한 사항
- 프로필 카드는 마이페이지에서만 보여지는 것이 아닌 다양한 곳에 사용될 예정
- 이로 인해 프로필 카드 정보만 가져와야 할 상황이 존재해 마이페이지의 정보를 반환하는 API와는 분리된 API가 있어야 한다 판단
- `AuthenticationPrincipal`이 아닌 memberId를 기반으로 반환해 다른 멤버의 프로필 정보도 확인할 수 있게 작업

### Result
https://youthing.atlassian.net/browse/COT-187

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->