### PR TITLE
[COT-209] Feature: 최초 로그인 시 출결 이벤트 구독 API

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/event/controller/EventController.java
+++ b/src/main/java/org/cotato/csquiz/api/event/controller/EventController.java
@@ -27,8 +27,8 @@ public class EventController {
 
     @Operation(summary = "최초 로그인 시 출결 알림 구독 API")
     @GetMapping(value = "/attendances", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> subscribeAttendance(@AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok().body(sseService.subscribeAttendance(memberId));
+    public ResponseEntity<SseEmitter> subscribeAttendance(@AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok().body(sseService.subscribeAttendance(member));
     }
 
     @Operation(summary = "출결 이벤트 발송 API")

--- a/src/main/java/org/cotato/csquiz/common/config/SecurityConfig.java
+++ b/src/main/java/org/cotato/csquiz/common/config/SecurityConfig.java
@@ -39,7 +39,6 @@ public class SecurityConfig {
             "/websocket/csquiz",
             "/v2/api/projects/**",
             "/v2/api/policies",
-            "/v2/api/events/**",
             "/v2/api/random-quizzes/**",
             "/v1/api/education/counts"
     };

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
@@ -38,7 +38,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             "/v1/api/generations/current",
             "/websocket/csquiz",
             "/v2/api/policies",
-            "/v2/api/events/**",
             "/v2/api/projects/**",
             "/v2/api/random-quizzes/**",
             "/v1/api/education/counts"

--- a/src/main/java/org/cotato/csquiz/common/sse/SseAttendanceRepository.java
+++ b/src/main/java/org/cotato/csquiz/common/sse/SseAttendanceRepository.java
@@ -26,6 +26,10 @@ public class SseAttendanceRepository {
         attendances.remove(memberId);
     }
 
+    public boolean existsById(Long memberId) {
+        return attendances.containsKey(memberId);
+    }
+
     public List<SseEmitter> findAll() {
         return attendances.values().stream()
                 .toList();

--- a/src/main/java/org/cotato/csquiz/common/sse/SseService.java
+++ b/src/main/java/org/cotato/csquiz/common/sse/SseService.java
@@ -1,10 +1,22 @@
 package org.cotato.csquiz.common.sse;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.domain.attendance.entity.Attendance;
+import org.cotato.csquiz.domain.attendance.enums.AttendanceOpenStatus;
 import org.cotato.csquiz.domain.attendance.repository.AttendanceRepository;
+import org.cotato.csquiz.domain.attendance.service.component.AttendanceReader;
+import org.cotato.csquiz.domain.attendance.util.AttendanceUtil;
+import org.cotato.csquiz.domain.auth.component.GenerationMemberAuthValidator;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.generation.entity.Generation;
+import org.cotato.csquiz.domain.generation.entity.Session;
+import org.cotato.csquiz.domain.generation.enums.SessionType;
+import org.cotato.csquiz.domain.generation.service.component.GenerationReader;
+import org.cotato.csquiz.domain.generation.service.component.SessionReader;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -15,17 +27,37 @@ public class SseService {
 
     private static final Long DEFAULT_TIMEOUT = 60 * 1000 * 60L;
 
+    private final GenerationReader generationReader;
+    private final GenerationMemberAuthValidator generationMemberAuthValidator;
     private final AttendanceRepository attendanceRepository;
     private final SseAttendanceRepository sseAttendanceRepository;
     private final SseSender sseSender;
+    private final SessionReader sessionReader;
+    private final AttendanceReader attendanceReader;
 
-    public SseEmitter subscribeAttendance(final Long memberId) {
+    public SseEmitter subscribeAttendance(final Member member) {
+        LocalDateTime now = LocalDateTime.now();
+        Generation currentGeneration = generationReader.findByDate(now.toLocalDate());
+        generationMemberAuthValidator.checkGenerationPermission(member, currentGeneration);
+
         SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+        setBaseEmitterConfiguration(member.getId(), sseEmitter);
+        sseAttendanceRepository.save(member.getId(), sseEmitter);
 
-        setBaseEmitterConfiguration(memberId, sseEmitter);
-        sseAttendanceRepository.save(memberId, sseEmitter);
+        Optional<Session> maybeSession = sessionReader.getByDate(now.toLocalDate());
+        if (maybeSession.isEmpty()) {
+            sseSender.sendInitialAttendanceStatus(sseEmitter, null, AttendanceOpenStatus.CLOSED);
+            return sseEmitter;
+        }
 
-        sseSender.sendInitialAttendanceStatus(sseEmitter);
+        Session session = maybeSession.get();
+        if (session.getSessionType() == SessionType.NO_ATTEND) {
+            sseSender.sendInitialAttendanceStatus(sseEmitter, null, AttendanceOpenStatus.CLOSED);
+            return sseEmitter;
+        }
+
+        Attendance attendance = attendanceReader.findBySession(session);
+        sseSender.sendInitialAttendanceStatus(sseEmitter, attendance.getId(), AttendanceUtil.getAttendanceOpenStatus(session.getSessionDateTime(), attendance, now));
 
         return sseEmitter;
     }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/component/AttendanceReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/component/AttendanceReader.java
@@ -32,4 +32,9 @@ public class AttendanceReader {
     public List<Attendance> getAllByIds(List<Long> attendanceIds) {
         return attendanceRepository.findAllByIdIn(attendanceIds);
     }
+
+    public Attendance findBySession(final Session session) {
+        return attendanceRepository.findBySessionId(session.getId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 세션의 출석 정보를 찾을 수 없습니다."));
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/repository/SessionRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/repository/SessionRepository.java
@@ -1,6 +1,7 @@
 package org.cotato.csquiz.domain.generation.repository;
 
 import jakarta.persistence.LockModeType;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.cotato.csquiz.domain.generation.enums.CSEducation;
@@ -25,4 +26,7 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
     Optional<Session> findByIdWithPessimisticXLock(@Param("sessionId") Long sessionId);
 
     List<Session> findAllByIdIn(List<Long> sessionIds);
+
+    @Query("SELECT s FROM Session s WHERE DATE(s.sessionDateTime) = :targetDate")
+    Optional<Session> findBySessionDate(@Param("targetDate") LocalDate targetDate);
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/component/SessionReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/component/SessionReader.java
@@ -1,7 +1,9 @@
 package org.cotato.csquiz.domain.generation.service.component;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.domain.attendance.entity.Attendance;
 import org.cotato.csquiz.domain.generation.entity.Generation;
@@ -35,5 +37,10 @@ public class SessionReader {
     public List<Session> getAllByAttendances(List<Attendance> attendances) {
         List<Long> sessionIds = attendances.stream().map(Attendance::getSessionId).toList();
         return sessionRepository.findAllByIdIn(sessionIds);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Session> getByDate(LocalDate date) {
+        return sessionRepository.findBySessionDate(date);
     }
 }


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

현재 활동 기수의 부원이 로그인 하면 출결 알림에 따른 이벤트 구독 요청을 한다.

1. 현재 기수 여부 확인 (현재 기수가 아니라면 예외 처리)
2. 오늘 날짜의 세션이 존재하지 않는 경우 -> 출결이 없음 (CLOSED)
3. 오늘 날짜의 세션이 있지만 NO_ATTEND인 경우 -> CLOSED
4. 오늘 출석이 존재 -> 현재 Open 상태 + attendanceId 전송


구체적인 내용은 아래 노션 문서 확인
https://www.notion.so/youthhing/Server-Tech-Doc-19787d592b6e80f398cdd25b00b9278d?pvs=4

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

sse emitter 를 활용해 구현한다.
서버 메모리가 고려되긴 하지만 활동 기수는 최대 40명이내이기에 우선 진행 후 모니터링한다.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/jira/software/projects/COT/boards/2?sprints=11

### Test (option)
<!-- 테스트 결과를 보여주세요. -->

![image](https://github.com/user-attachments/assets/03f4e435-6f23-4587-9ee8-6fec889d3e47)


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->