### PR TITLE
[COT-243] Feature: 기수 노출 필드 추가

### DIFF
--- a/src/main/java/org/cotato/csquiz/domain/generation/entity/Generation.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/entity/Generation.java
@@ -56,4 +56,8 @@ public class Generation extends BaseTimeEntity {
     public void changePeriod(GenerationPeriod period) {
         this.period = period;
     }
+
+    public void updateVisible(boolean visible) {
+        this.visible = visible;
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/entity/Generation.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/entity/Generation.java
@@ -38,11 +38,15 @@ public class Generation extends BaseTimeEntity {
     @Column(name = "generation_recruiting")
     private Boolean isRecruit;
 
+    @Column(name = "visible")
+    private boolean visible;
+
     @Builder
     public Generation(Integer number, GenerationPeriod period) {
         this.number = number;
         this.period = period;
-        isRecruit = false;
+        this.isRecruit = false;
+        this.visible = true;
     }
 
     public void changeRecruit(Boolean isRecruit) {

--- a/src/main/java/org/cotato/csquiz/domain/generation/repository/GenerationRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/repository/GenerationRepository.java
@@ -25,4 +25,6 @@ public interface GenerationRepository extends JpaRepository<Generation, Long> {
 
     @Query(value = "SELECT * FROM generation g WHERE g.generation_end_date < :currentDate ORDER BY g.generation_end_date DESC LIMIT 1", nativeQuery = true)
     Optional<Generation> findPreviousGenerationByCurrentDate(@Param("currentDate") LocalDate currentDate);
+
+    List<Generation> findAllByVisibleTrue();
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/GenerationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/GenerationService.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class GenerationService {
 
-    private static final Integer BASE_NUMBER = 1;
     private final GenerationRepository generationRepository;
     private final GenerationReader generationReader;
 
@@ -60,7 +59,7 @@ public class GenerationService {
     }
 
     public List<GenerationInfoResponse> findGenerations() {
-        return generationRepository.findByNumberGreaterThanEqual(BASE_NUMBER).stream()
+        return generationReader.getGenerations().stream()
                 .sorted(Comparator.comparing(Generation::getNumber))
                 .map(GenerationInfoResponse::from)
                 .toList();

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/component/GenerationReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/component/GenerationReader.java
@@ -1,7 +1,9 @@
 package org.cotato.csquiz.domain.generation.service.component;
 
+import io.netty.resolver.dns.DnsServerAddresses;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.domain.generation.entity.Generation;
 import org.cotato.csquiz.domain.generation.repository.GenerationRepository;
@@ -22,5 +24,9 @@ public class GenerationReader {
 
     public Generation findById(Long generationId) {
         return generationRepository.findById(generationId).orElseThrow(() -> new EntityNotFoundException("해당 기수를 찾을 수 없습니다."));
+    }
+
+    public List<Generation> getGenerations() {
+        return generationRepository.findAllByVisibleTrue();
     }
 }

--- a/src/test/java/org/cotato/csquiz/domain/generation/service/GenerationServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/generation/service/GenerationServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -191,5 +192,26 @@ class GenerationServiceTest {
         // then
         assertThat(generation.getPeriod().getStartDate()).isEqualTo(startDate);
         assertThat(generation.getPeriod().getEndDate()).isEqualTo(endDate);
+    }
+
+    @Test
+    void 기수_목록_조회() {
+        // given
+        Generation generation1 = Generation.builder().number(3)
+                .period(GenerationPeriod.of(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 5, 1)))
+                .build();
+
+        Generation generation2 = Generation.builder().number(3)
+                .period(GenerationPeriod.of(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 5, 1)))
+                .build();
+        generation2.updateVisible(false);
+
+        when(generationReader.getGenerations()).thenReturn(List.of(generation1));
+
+        // when
+        List<GenerationInfoResponse> generations = generationService.findGenerations();
+
+        // then
+        assertThat(generations).hasSize(1);
     }
 }

--- a/src/test/java/org/cotato/csquiz/domain/generation/service/GenerationServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/generation/service/GenerationServiceTest.java
@@ -146,6 +146,7 @@ class GenerationServiceTest {
         assertThat(savedGeneration.getNumber()).isEqualTo(generationNumber);
         assertThat(savedGeneration.getPeriod().getStartDate()).isEqualTo(startDate);
         assertThat(savedGeneration.getPeriod().getEndDate()).isEqualTo(endDate);
+        assertThat(savedGeneration.isVisible()).isEqualTo(true);
     }
 
     @Test


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

기수 목록 조회 시 4 ~ 7기가 노출된다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

기수 노출 여부 필드를 추가하고 기수 조회 시 generationReader를 활용하자


### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->
```sql
# 기수에 노출 여부 컬럼 추가
    alter table generation add column visible bit

# 
update generation set visible = 1 where generation_id in (5,6,7,8);