### PR TITLE
[COT-239] Feature: 부원 이름 노출 시 정렬

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -11,11 +11,11 @@ import org.cotato.csquiz.api.admin.dto.MemberApproveRequest;
 import org.cotato.csquiz.api.admin.dto.MemberInfoResponse;
 import org.cotato.csquiz.api.admin.dto.UpdateActiveMemberToOldMemberRequest;
 import org.cotato.csquiz.api.admin.dto.UpdateMemberRoleRequest;
-import org.cotato.csquiz.api.member.dto.SearchedMembersResponse;
 import org.cotato.csquiz.api.member.dto.DeactivateRequest;
 import org.cotato.csquiz.api.member.dto.MemberMyPageInfoResponse;
 import org.cotato.csquiz.api.member.dto.MemberResponse;
 import org.cotato.csquiz.api.member.dto.ProfileInfoResponse;
+import org.cotato.csquiz.api.member.dto.SearchedMembersResponse;
 import org.cotato.csquiz.api.member.dto.UpdatePasswordRequest;
 import org.cotato.csquiz.api.member.dto.UpdatePhoneNumberRequest;
 import org.cotato.csquiz.api.member.dto.UpdateProfileInfoRequest;
@@ -28,6 +28,8 @@ import org.cotato.csquiz.domain.auth.service.AdminMemberService;
 import org.cotato.csquiz.domain.auth.service.MemberService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -35,7 +37,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -134,7 +135,9 @@ public class MemberController {
     @Operation(summary = "회원 상태에 따른 조회 요청 API")
     @RoleAuthority(MemberRole.ADMIN)
     @GetMapping(params = "status")
-    public ResponseEntity<Page<MemberResponse>> findMembersByStatus(@RequestParam("status") MemberStatus status, Pageable pageable) {
+    public ResponseEntity<Page<MemberResponse>> findMembersByStatus(
+            @RequestParam("status") MemberStatus status,
+            @PageableDefault(sort = {"name"}, direction = Sort.Direction.ASC) Pageable pageable) {
         return ResponseEntity.ok().body(memberService.getMembersByStatus(status, pageable));
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -44,7 +44,9 @@ import org.cotato.csquiz.domain.generation.repository.GenerationMemberRepository
 import org.cotato.csquiz.domain.generation.service.component.GenerationReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -266,7 +268,19 @@ public class MemberService {
     }
 
     public Page<MemberResponse> getMembersByStatus(final MemberStatus status, Pageable pageable) {
-        return memberRepository.findAllByStatus(status, pageable).map(member -> MemberResponse.of(member, findBackFourNumber(member)));
+        switch (status) {
+            case APPROVED, RETIRED-> {
+                Sort sort = Sort.by(
+                        Sort.Order.desc("passedGenerationNumber"),
+                        Sort.Order.asc("name")
+                );
+                Pageable pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+                return memberRepository.findAllByStatus(status, pageRequest).map(member -> MemberResponse.of(member, findBackFourNumber(member)));
+            }
+            default -> {
+                return memberRepository.findAllByStatus(status, pageable).map(member -> MemberResponse.of(member, findBackFourNumber(member)));
+            }
+        }
     }
 
     @Transactional


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

부원 이름을 노출할 때 정렬 기준이 없다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

1. 부원 목록 조회 시 기수 내림차순
2. 이름 오름차순으로 정렬하자.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->