### PR TITLE
[COT-253] Hotfix: 출결 기록 변경 시 세션 타입과 변경할 결과 비교 로직 에러 해결

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
+++ b/src/main/java/org/cotato/csquiz/api/attendance/controller/AttendanceController.java
@@ -81,7 +81,7 @@ public class AttendanceController {
     public ResponseEntity<Void> updateAttendanceRecords(
             @PathVariable("attendance-id") Long attendanceId,
             @RequestBody @Valid UpdateAttendanceRecordRequest request) {
-        attendanceRecordService.updateAttendanceRecords(attendanceId, request.memberId(), request.result());
+        attendanceRecordService.updateAttendanceRecord(attendanceId, request.memberId(), request.result());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordService.java
@@ -151,25 +151,6 @@ public class AttendanceRecordService {
     }
 
     @Transactional
-    public void updateUnrecordedAttendanceRecord(Long sessionId) {
-        Attendance attendance = attendanceRepository.findBySessionId(sessionId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 세션에 대한 출석이 생성되지 않았습니다."));
-        Session session = sessionReader.findById(sessionId);
-        // 출결 입력을 한 부원
-        Set<Long> attendedMember = attendanceRecordRepository.findAllByAttendanceId(attendance.getId()).stream()
-                .map(AttendanceRecord::getMemberId)
-                .collect(Collectors.toUnmodifiableSet());
-
-        List<AttendanceRecord> unrecordedMemberIds = memberReader.findAllGenerationMember(session.getGeneration()).stream()
-                .map(Member::getId)
-                .filter(id -> !attendedMember.contains(id))
-                .map(id -> AttendanceRecord.absentRecord(attendance, id))
-                .toList();
-
-        attendanceRecordRepository.saveAll(unrecordedMemberIds);
-    }
-
-    @Transactional
     public void updateAttendanceRecord(Long attendanceId, Long memberId, AttendanceResult attendanceResult) {
         Attendance attendance = attendanceRepository.findById(attendanceId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 출석이 존재하지 않습니다"));

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordService.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordService.java
@@ -170,19 +170,15 @@ public class AttendanceRecordService {
     }
 
     @Transactional
-    public void updateAttendanceRecords(Long attendanceId, Long memberId, AttendanceResult attendanceResult) {
+    public void updateAttendanceRecord(Long attendanceId, Long memberId, AttendanceResult attendanceResult) {
         Attendance attendance = attendanceRepository.findById(attendanceId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 출석이 존재하지 않습니다"));
 
         AttendanceRecord attendanceRecord = attendanceRecordRepository.findByMemberIdAndAttendanceId(memberId, attendanceId)
                 .orElseGet(() -> AttendanceRecord.absentRecord(attendance, memberId));
-        Session session = sessionReader.findById(attendance.getSessionId());
 
-        if (!session.getSessionType().isSameType(attendanceRecord.getAttendanceType())) {
-            throw new AppException(ErrorCode.INVALID_RECORD_UPDATE);
-        }
-        // Todo https://github.com/IT-Cotato/COTATO-BE/issues/204
         attendanceRecord.updateAttendanceResult(attendanceResult);
+        // Todo https://github.com/IT-Cotato/COTATO-BE/issues/204
 
         attendanceRecordRepository.save(attendanceRecord);
     }

--- a/src/main/java/org/cotato/csquiz/domain/attendance/service/component/AttendanceRecordReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/attendance/service/component/AttendanceRecordReader.java
@@ -1,10 +1,12 @@
 package org.cotato.csquiz.domain.attendance.service.component;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.cotato.csquiz.domain.attendance.entity.Attendance;
 import org.cotato.csquiz.domain.attendance.entity.AttendanceRecord;
 import org.cotato.csquiz.domain.attendance.repository.AttendanceRecordRepository;
+import org.cotato.csquiz.domain.auth.entity.Member;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,5 +24,9 @@ public class AttendanceRecordReader {
 
     public boolean isAttendanceRecordExist(final Attendance attendance) {
         return attendanceRecordRepository.existsByAttendanceId(attendance.getId());
+    }
+
+    public Optional<AttendanceRecord> getByAttendanceAndMember(Attendance attendance, Member member) {
+        return attendanceRecordRepository.findByMemberIdAndAttendanceId(member.getId(), attendance.getId());
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/enums/SessionType.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/enums/SessionType.java
@@ -2,6 +2,7 @@ package org.cotato.csquiz.domain.generation.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceType;
 
 @Getter
@@ -47,5 +48,17 @@ public enum SessionType {
 
     public boolean hasOnline() {
         return this == ONLINE || this == ALL;
+    }
+
+    public boolean canChangeResult(AttendanceResult attendanceResult) {
+        if (attendanceResult == null) {
+            return false;
+        }
+
+        return switch (attendanceResult) {
+            case ONLINE -> this == ONLINE || this == ALL;
+            case OFFLINE -> this == OFFLINE || this == ALL;
+            default -> false;
+        };
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/generation/service/component/SessionReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/generation/service/component/SessionReader.java
@@ -43,4 +43,9 @@ public class SessionReader {
     public Optional<Session> getByDate(LocalDate date) {
         return sessionRepository.findBySessionDate(date);
     }
+
+    public Session getByAttendance(Attendance attendance) {
+        return sessionRepository.findById(attendance.getSessionId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 세션을 찾을 수 없습니다."));
+    }
 }

--- a/src/test/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordServiceTest.java
@@ -1,0 +1,50 @@
+package org.cotato.csquiz.domain.attendance.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.cotato.csquiz.domain.attendance.entity.Attendance;
+import org.cotato.csquiz.domain.attendance.entity.AttendanceRecord;
+import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
+import org.cotato.csquiz.domain.attendance.repository.AttendanceRecordRepository;
+import org.cotato.csquiz.domain.attendance.repository.AttendanceRepository;
+import org.cotato.csquiz.domain.generation.entity.Session;
+import org.cotato.csquiz.domain.generation.enums.SessionType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class AttendanceRecordServiceTest {
+
+    @InjectMocks
+    private AttendanceRecordService attendanceRecordService;
+
+    @Mock
+    private AttendanceRepository attendanceRepository;
+
+    @Mock
+    private AttendanceRecordRepository attendanceRecordRepository;
+
+
+    @Test
+    void 세션_타입에_맞는_출결_기록_변경() {
+        // given
+        Session session = Session.builder().sessionType(SessionType.OFFLINE).build();
+        Attendance attendance = Attendance.builder().session(session).build();
+        AttendanceRecord attendanceRecord = AttendanceRecord.absentRecord(attendance, 1L);
+
+        when(attendanceRepository.findById(any())).thenReturn(Optional.of(attendance));
+        when(attendanceRecordRepository.findByMemberIdAndAttendanceId(any(), any())).thenReturn(Optional.of(attendanceRecord));
+
+        // when
+        attendanceRecordService.updateAttendanceRecord(1L, 1L, AttendanceResult.OFFLINE);
+
+        // then
+        Assertions.assertEquals(AttendanceResult.OFFLINE, attendanceRecord.getAttendanceResult());
+    }
+}

--- a/src/test/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordServiceTest.java
@@ -4,6 +4,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.domain.attendance.entity.Attendance;
 import org.cotato.csquiz.domain.attendance.entity.AttendanceRecord;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
@@ -61,5 +63,24 @@ class AttendanceRecordServiceTest {
 
         // then
         Assertions.assertEquals(AttendanceResult.OFFLINE, attendanceRecord.getAttendanceResult());
+    }
+
+    @Test
+    void 세션_타입에_맞지_않는_출결_기록_변경() {
+        // given
+        Session session = Session.builder().sessionType(SessionType.ONLINE).build();
+        Attendance attendance = Attendance.builder().session(session).build();
+        AttendanceRecord attendanceRecord = AttendanceRecord.absentRecord(attendance, 1L);
+        Member member = Member.defaultMember("test", "test", "test", "test");
+
+        when(attendanceReader.findById(any())).thenReturn(attendance);
+        when(attendanceRecordReader.getByAttendanceAndMember(any(), any())).thenReturn(Optional.of(attendanceRecord));
+        when(sessionReader.getByAttendance(attendance)).thenReturn(session);
+        when(memberReader.findById(any())).thenReturn(member);
+
+        // when, then
+        AppException appException = Assertions.assertThrows(AppException.class,
+                () -> attendanceRecordService.updateAttendanceRecord(1L, 1L, AttendanceResult.OFFLINE));
+        Assertions.assertEquals(ErrorCode.INVALID_RECORD_UPDATE, appException.getErrorCode());
     }
 }

--- a/src/test/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/attendance/service/AttendanceRecordServiceTest.java
@@ -8,9 +8,13 @@ import org.cotato.csquiz.domain.attendance.entity.Attendance;
 import org.cotato.csquiz.domain.attendance.entity.AttendanceRecord;
 import org.cotato.csquiz.domain.attendance.enums.AttendanceResult;
 import org.cotato.csquiz.domain.attendance.repository.AttendanceRecordRepository;
-import org.cotato.csquiz.domain.attendance.repository.AttendanceRepository;
+import org.cotato.csquiz.domain.attendance.service.component.AttendanceReader;
+import org.cotato.csquiz.domain.attendance.service.component.AttendanceRecordReader;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.service.component.MemberReader;
 import org.cotato.csquiz.domain.generation.entity.Session;
 import org.cotato.csquiz.domain.generation.enums.SessionType;
+import org.cotato.csquiz.domain.generation.service.component.SessionReader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,11 +29,19 @@ class AttendanceRecordServiceTest {
     private AttendanceRecordService attendanceRecordService;
 
     @Mock
-    private AttendanceRepository attendanceRepository;
+    private AttendanceReader attendanceReader;
+
+    @Mock
+    private AttendanceRecordReader attendanceRecordReader;
+
+    @Mock
+    private SessionReader sessionReader;
+
+    @Mock
+    private MemberReader memberReader;
 
     @Mock
     private AttendanceRecordRepository attendanceRecordRepository;
-
 
     @Test
     void 세션_타입에_맞는_출결_기록_변경() {
@@ -37,9 +49,12 @@ class AttendanceRecordServiceTest {
         Session session = Session.builder().sessionType(SessionType.OFFLINE).build();
         Attendance attendance = Attendance.builder().session(session).build();
         AttendanceRecord attendanceRecord = AttendanceRecord.absentRecord(attendance, 1L);
+        Member member = Member.defaultMember("test", "test", "test", "test");
 
-        when(attendanceRepository.findById(any())).thenReturn(Optional.of(attendance));
-        when(attendanceRecordRepository.findByMemberIdAndAttendanceId(any(), any())).thenReturn(Optional.of(attendanceRecord));
+        when(attendanceReader.findById(any())).thenReturn(attendance);
+        when(attendanceRecordReader.getByAttendanceAndMember(any(), any())).thenReturn(Optional.of(attendanceRecord));
+        when(sessionReader.getByAttendance(attendance)).thenReturn(session);
+        when(memberReader.findById(any())).thenReturn(member);
 
         // when
         attendanceRecordService.updateAttendanceRecord(1L, 1L, AttendanceResult.OFFLINE);


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

관리자가 출결 기록을 업데이트하는 과정에서 에러가 발생한다.
업데이트 하는 경우 세션 타입에 맞는 출석 결과 확인 시 attendance_type과 session_type을 비교해서 문제가 발생 중

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

attendance_type과의 비교가 아닌 바꾸려는 결과 'attendance_result'와 비교하자.


### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-253&sprints=13

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->