### PR TITLE
[COT-269] Refactor: 전화번호 및 비밀번호 검증 어노테이션 구현

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/auth/dto/JoinRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/auth/dto/JoinRequest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.Builder;
 import org.cotato.csquiz.api.policy.dto.CheckPolicyRequest;
+import org.cotato.csquiz.common.validator.Phone;
 
 @Builder
 public record JoinRequest(
@@ -22,7 +23,7 @@ public record JoinRequest(
         @NotBlank(message = "올바른 형식의 이름을 입력해주세요.")
         String name,
         @NotNull(message = "전화번호를 입력해주세요.")
-        @Size(min = 11, max = 11, message = "'-'없이 11자리의 전화번호를 입력해주세요.")
+        @Phone(message = "전화번호는 010으로 시작하는 11자리여야합니다.")
         String phoneNumber,
 
         @Schema(description = "동의 표시한 정책 목록")

--- a/src/main/java/org/cotato/csquiz/api/auth/dto/JoinRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/auth/dto/JoinRequest.java
@@ -5,11 +5,10 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import lombok.Builder;
 import org.cotato.csquiz.api.policy.dto.CheckPolicyRequest;
+import org.cotato.csquiz.common.validator.Password;
 import org.cotato.csquiz.common.validator.Phone;
 
 @Builder
@@ -18,7 +17,7 @@ public record JoinRequest(
         @NotBlank(message = "공백이 아닌 올바른 형식의 메일 주소를 입력해주세요.")
         String email,
         @Size(min = 8, max = 16, message = "비밀번호는 8~16자리여야합니다.")
-        @NotNull(message = "비밀번호를 입력해주세요.")
+        @Password(message = "비밀번호는 영문, 숫자, 특수문자를 포함해야합니다.")
         String password,
         @NotBlank(message = "올바른 형식의 이름을 입력해주세요.")
         String name,

--- a/src/main/java/org/cotato/csquiz/api/member/dto/UpdatePasswordRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/UpdatePasswordRequest.java
@@ -1,9 +1,11 @@
 package org.cotato.csquiz.api.member.dto;
 
 import jakarta.validation.constraints.NotNull;
+import org.cotato.csquiz.common.validator.Password;
 
 public record UpdatePasswordRequest(
         @NotNull
+        @Password
         String password
 ) {
 }

--- a/src/main/java/org/cotato/csquiz/common/validator/Password.java
+++ b/src/main/java/org/cotato/csquiz/common/validator/Password.java
@@ -1,0 +1,20 @@
+package org.cotato.csquiz.common.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PasswordValidator.class)
+public @interface Password {
+
+    String message() default "Invalid password format";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/cotato/csquiz/common/validator/PasswordValidator.java
+++ b/src/main/java/org/cotato/csquiz/common/validator/PasswordValidator.java
@@ -1,0 +1,25 @@
+package org.cotato.csquiz.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&.])[A-Za-z\\d@$!%*#?&.]{8,16}$");
+
+    @Override
+    public boolean isValid(String password, ConstraintValidatorContext constraintValidatorContext) {
+        if (password == null) {
+            return false;
+        }
+
+        if (!PASSWORD_PATTERN.matcher(password).matches()) {
+            throw new AppException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/validator/PasswordValidator.java
+++ b/src/main/java/org/cotato/csquiz/common/validator/PasswordValidator.java
@@ -3,8 +3,6 @@ package org.cotato.csquiz.common.validator;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
-import org.cotato.csquiz.common.error.ErrorCode;
-import org.cotato.csquiz.common.error.exception.AppException;
 
 public class PasswordValidator implements ConstraintValidator<Password, String> {
 
@@ -16,10 +14,6 @@ public class PasswordValidator implements ConstraintValidator<Password, String> 
             return false;
         }
 
-        if (!PASSWORD_PATTERN.matcher(password).matches()) {
-            throw new AppException(ErrorCode.INVALID_PASSWORD);
-        }
-
-        return true;
+        return PASSWORD_PATTERN.matcher(password).matches();
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/validator/Phone.java
+++ b/src/main/java/org/cotato/csquiz/common/validator/Phone.java
@@ -1,0 +1,20 @@
+package org.cotato.csquiz.common.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PhoneValidator.class)
+public @interface Phone {
+
+    String message() default "Invalid phone number format";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/cotato/csquiz/common/validator/PhoneValidator.java
+++ b/src/main/java/org/cotato/csquiz/common/validator/PhoneValidator.java
@@ -1,0 +1,32 @@
+package org.cotato.csquiz.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+
+public class PhoneValidator implements ConstraintValidator<Phone, String> {
+
+    private static final Pattern PHONE_PATTERN = Pattern.compile("^010\\d{8}$");
+
+    private static final String START_NUMBER = "010";
+
+
+    @Override
+    public boolean isValid(String phone, ConstraintValidatorContext constraintValidatorContext) {
+        if (phone == null) {
+            return false;
+        }
+
+        if (phone.startsWith(START_NUMBER) ){
+            throw new AppException(ErrorCode.INVALID_PHONE_NUMBER_PREFIX);
+        }
+
+        if (!PHONE_PATTERN.matcher(phone).matches()) {
+            throw new AppException(ErrorCode.INVALID_PHONE_NUMBER_FORMAT);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/validator/PhoneValidator.java
+++ b/src/main/java/org/cotato/csquiz/common/validator/PhoneValidator.java
@@ -8,7 +8,6 @@ public class PhoneValidator implements ConstraintValidator<Phone, String> {
 
     private static final Pattern PHONE_PATTERN = Pattern.compile("^010\\d{8}$");
 
-
     @Override
     public boolean isValid(String phone, ConstraintValidatorContext constraintValidatorContext) {
         if (phone == null) {

--- a/src/main/java/org/cotato/csquiz/common/validator/PhoneValidator.java
+++ b/src/main/java/org/cotato/csquiz/common/validator/PhoneValidator.java
@@ -3,14 +3,10 @@ package org.cotato.csquiz.common.validator;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
-import org.cotato.csquiz.common.error.ErrorCode;
-import org.cotato.csquiz.common.error.exception.AppException;
 
 public class PhoneValidator implements ConstraintValidator<Phone, String> {
 
     private static final Pattern PHONE_PATTERN = Pattern.compile("^010\\d{8}$");
-
-    private static final String START_NUMBER = "010";
 
 
     @Override
@@ -19,14 +15,6 @@ public class PhoneValidator implements ConstraintValidator<Phone, String> {
             return false;
         }
 
-        if (!phone.startsWith(START_NUMBER) ){
-            throw new AppException(ErrorCode.INVALID_PHONE_NUMBER_PREFIX);
-        }
-
-        if (!PHONE_PATTERN.matcher(phone).matches()) {
-            throw new AppException(ErrorCode.INVALID_PHONE_NUMBER_FORMAT);
-        }
-
-        return true;
+        return PHONE_PATTERN.matcher(phone).matches();
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/validator/PhoneValidator.java
+++ b/src/main/java/org/cotato/csquiz/common/validator/PhoneValidator.java
@@ -19,7 +19,7 @@ public class PhoneValidator implements ConstraintValidator<Phone, String> {
             return false;
         }
 
-        if (phone.startsWith(START_NUMBER) ){
+        if (!phone.startsWith(START_NUMBER) ){
             throw new AppException(ErrorCode.INVALID_PHONE_NUMBER_PREFIX);
         }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
@@ -59,8 +59,6 @@ public class AuthService {
     @Transactional
     public JoinResponse createMember(final JoinRequest request) {
         validateService.checkDuplicateEmail(request.email());
-        validateService.checkPasswordPattern(request.password());
-        validateService.checkPhoneNumber(request.phoneNumber());
 
         String encryptedPhoneNumber = encryptService.encryptPhoneNumber(request.phoneNumber());
         validateService.checkDuplicatePhoneNumber(encryptedPhoneNumber);

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/MemberService.java
@@ -72,7 +72,6 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final EncryptService encryptService;
-    private final ValidateService validateService;
     private final S3Uploader s3Uploader;
     private final ProfileLinkRepository profileLinkRepository;
     private final GenerationMemberRepository generationMemberRepository;
@@ -95,7 +94,6 @@ public class MemberService {
 
     @Transactional
     public void updatePassword(final Member member, final String password) {
-        validateService.checkPasswordPattern(password);
         validateIsSameBefore(member.getPassword(), password);
 
         member.updatePassword(bCryptPasswordEncoder.encode(password));

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/ValidateService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/ValidateService.java
@@ -15,8 +15,8 @@ import org.springframework.stereotype.Service;
 public class ValidateService {
 
     private static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&.])[A-Za-z\\d@$!%*#?&.]{8,16}$";
-    private static final int PHONE_NUMBER_LENGTH = 11;
-    private static final String PHONE_NUMBER_PREFIX = "010";
+
+
     private final MemberRepository memberRepository;
 
     public void checkDuplicateEmail(String email) {
@@ -50,19 +50,6 @@ public class ValidateService {
         Matcher matcher = pattern.matcher(password);
         if (!matcher.matches()) {
             throw new AppException(ErrorCode.INVALID_PASSWORD);
-        }
-    }
-
-    public void checkPhoneNumber(String phoneNumber) {
-        if (!phoneNumber.startsWith(PHONE_NUMBER_PREFIX)) {
-            log.error("[전화번호 에러]: 010으로 시작하지 않음");
-            throw new AppException(ErrorCode.INVALID_PHONE_NUMBER_PREFIX);
-        }
-        try {
-            Integer.parseInt(phoneNumber);
-        } catch (Exception e) {
-            log.error("[전화번호 에러]: 문자열 파싱 에러");
-            throw new AppException(ErrorCode.INVALID_PHONE_NUMBER_FORMAT);
         }
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/ValidateService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/ValidateService.java
@@ -1,21 +1,16 @@
 package org.cotato.csquiz.domain.auth.service;
 
-import org.cotato.csquiz.common.error.exception.AppException;
-import org.cotato.csquiz.common.error.ErrorCode;
-import org.cotato.csquiz.domain.auth.repository.MemberRepository;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+import org.cotato.csquiz.domain.auth.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ValidateService {
-
-    private static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&.])[A-Za-z\\d@$!%*#?&.]{8,16}$";
-
 
     private final MemberRepository memberRepository;
 
@@ -42,14 +37,6 @@ public class ValidateService {
     public void emailExist(String email) {
         if (!memberRepository.existsByEmail(email)) {
             throw new AppException(ErrorCode.EMAIL_NOT_FOUND);
-        }
-    }
-
-    public void checkPasswordPattern(String password) {
-        Pattern pattern = Pattern.compile(PASSWORD_PATTERN);
-        Matcher matcher = pattern.matcher(password);
-        if (!matcher.matches()) {
-            throw new AppException(ErrorCode.INVALID_PASSWORD);
         }
     }
 }


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

기존 전화번호와 비밀번호는 서비스 로직 내부에서 검증을 진행했다.
하지만 이는 사용자 입력 값을 검증하는 것으로 서비스 로직 내부에서 검증을 제외하고 싶다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

어노테이션을 활용해 검증 위치를 앞으로 당긴다.
validation 패키지를 활용한다.

단, 기존 프론트엔드 개발자의 요구사항으로 인해 전화번호 검증 로직 같은 경우엔 010으로 시작하지 않는 경우와 11자리 숫자가 아닌 경우를 모두 포함해야하므로 AppException을 내려준다. (추후 논의 후 수정 가능)

✅ 논의 후 MethodArgumentException으로 처리하기로 결정

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->