### PR TITLE
[COT-263] Feature: 모집 알림 신청 API 구현

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/cotato/csquiz/api/recruitment/controller/RecruitmentController.java
@@ -2,12 +2,17 @@ package org.cotato.csquiz.api.recruitment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.api.recruitment.dto.RecruitmentInfoResponse;
+import org.cotato.csquiz.api.recruitment.dto.RequestRecruitmentNotificationRequest;
 import org.cotato.csquiz.domain.recruitment.service.RecruitmentInformationService;
+import org.cotato.csquiz.domain.recruitment.service.RecruitmentNotificationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,10 +24,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecruitmentController {
 
     private final RecruitmentInformationService recruitmentInformationService;
+    private final RecruitmentNotificationService recruitmentNotificationService;
 
     @GetMapping
     @Operation(summary = "모집 정보 반환 API")
     public ResponseEntity<RecruitmentInfoResponse> findRecruitmentInfo() {
         return ResponseEntity.ok().body(recruitmentInformationService.findRecruitmentInfo());
+    }
+
+    @PostMapping("/notification")
+    @Operation(summary = "모집 알림 신청 API")
+    public ResponseEntity<Void> requestRecruitmentNotification(
+            @RequestBody @Valid RequestRecruitmentNotificationRequest request) {
+        recruitmentNotificationService.requestRecruitmentNotification(request.email(), request.policyCheck());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/cotato/csquiz/api/recruitment/dto/RequestRecruitmentNotificationRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/recruitment/dto/RequestRecruitmentNotificationRequest.java
@@ -1,0 +1,13 @@
+package org.cotato.csquiz.api.recruitment.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record RequestRecruitmentNotificationRequest(
+        @NotNull
+        Boolean policyCheck,
+        @Email
+        @NotNull
+        String email
+) {
+}

--- a/src/main/java/org/cotato/csquiz/common/config/SecurityConfig.java
+++ b/src/main/java/org/cotato/csquiz/common/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
             "/v2/api/policies",
             "/v2/api/random-quizzes/**",
             "/v1/api/education/counts",
-            "/v2/api/recruitments"
+            "/v2/api/recruitments",
+            "/v2/api/recruitments/notification",
     };
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthorizationFilter.java
@@ -27,6 +27,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private static final String AUTH_PATH = "/v1/api/auth/**";
     private static final String LOGIN_PATH = "/login";
+    private static final String RECRUITMENT_NOTIFICATION_PATH = "/v2/api/recruitments/notification";
 
     private static final String[] WHITE_LIST = {
             "/swagger-ui/**",
@@ -71,7 +72,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
         log.info("요청 경로 및 메서드: {}, {}", path, request.getMethod());
-        return isAuthPath(request.getRequestURI()) || isWhiteList(request);
+        return isAuthPath(request.getRequestURI()) || isRecruitmentNotificationPath(request.getRequestURI())
+                || isWhiteList(request);
     }
 
     private boolean isWhiteList(HttpServletRequest request) {
@@ -83,5 +85,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private boolean isAuthPath(String requestURI) {
         AntPathMatcher pathMatcher = new AntPathMatcher();
         return pathMatcher.match(AUTH_PATH, requestURI) || pathMatcher.match(LOGIN_PATH, requestURI);
+    }
+
+    private boolean isRecruitmentNotificationPath(String requestURI) {
+        AntPathMatcher pathMatcher = new AntPathMatcher();
+        return pathMatcher.match(RECRUITMENT_NOTIFICATION_PATH, requestURI);
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -111,6 +111,7 @@ public enum ErrorCode {
     PROFILE_IMAGE_NOT_EXIST(HttpStatus.BAD_REQUEST, "PI-401", "요청에 프로필 이미지가 존재하지 않습니다."),
 
     //모집 알림 관련
+    ALREADY_REQUEST_NOTIFICATION(HttpStatus.CONFLICT, "RE-301", "이미 모집 신청을 완료했습니다"),
     RECRUITMENT_INFO_COUNT_INVALID(HttpStatus.CONFLICT, "RE-302", "모집 정보 갯수가 없거나 2개 이상힙니디."),
 
     // 500 오류 -> 서버측에서 처리가 실패한 부분들

--- a/src/main/java/org/cotato/csquiz/domain/recruitment/entity/RecruitmentNotificationRequester.java
+++ b/src/main/java/org/cotato/csquiz/domain/recruitment/entity/RecruitmentNotificationRequester.java
@@ -36,4 +36,16 @@ public class RecruitmentNotificationRequester extends BaseTimeEntity {
     @Column(name = "send_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private SendStatus sendStatus;
+
+    private RecruitmentNotificationRequester(String email, Boolean policyChecked, LocalDateTime requestTime,
+                                             SendStatus sendStatus) {
+        this.email = email;
+        this.policyChecked = policyChecked;
+        this.requestTime = requestTime;
+        this.sendStatus = sendStatus;
+    }
+
+    public static RecruitmentNotificationRequester of(String email, Boolean policyChecked) {
+        return new RecruitmentNotificationRequester(email, policyChecked, LocalDateTime.now(), SendStatus.NOT_SENT);
+    }
 }

--- a/src/main/java/org/cotato/csquiz/domain/recruitment/entity/RecruitmentNotificationRequester.java
+++ b/src/main/java/org/cotato/csquiz/domain/recruitment/entity/RecruitmentNotificationRequester.java
@@ -2,6 +2,8 @@ package org.cotato.csquiz.domain.recruitment.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,5 +34,6 @@ public class RecruitmentNotificationRequester extends BaseTimeEntity {
     private Boolean policyChecked;
 
     @Column(name = "send_status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private SendStatus sendStatus;
 }

--- a/src/main/java/org/cotato/csquiz/domain/recruitment/repository/RecruitmentNotificationRequesterRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/recruitment/repository/RecruitmentNotificationRequesterRepository.java
@@ -1,0 +1,10 @@
+package org.cotato.csquiz.domain.recruitment.repository;
+
+import org.cotato.csquiz.domain.recruitment.entity.RecruitmentNotificationRequester;
+import org.cotato.csquiz.domain.recruitment.enums.SendStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecruitmentNotificationRequesterRepository extends
+        JpaRepository<RecruitmentNotificationRequester, Long> {
+    boolean existsByEmailAndSendStatus(String recruitEmail, SendStatus sendStatus);
+}

--- a/src/main/java/org/cotato/csquiz/domain/recruitment/service/RecruitmentNotificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/recruitment/service/RecruitmentNotificationService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class RecruitmentNotificationService {
 
     private final RecruitmentNotificationRequesterReader recruitmentNotificationRequesterReader;

--- a/src/main/java/org/cotato/csquiz/domain/recruitment/service/RecruitmentNotificationService.java
+++ b/src/main/java/org/cotato/csquiz/domain/recruitment/service/RecruitmentNotificationService.java
@@ -1,0 +1,34 @@
+package org.cotato.csquiz.domain.recruitment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+import org.cotato.csquiz.domain.recruitment.entity.RecruitmentNotificationRequester;
+import org.cotato.csquiz.domain.recruitment.enums.SendStatus;
+import org.cotato.csquiz.domain.recruitment.repository.RecruitmentNotificationRequesterRepository;
+import org.cotato.csquiz.domain.recruitment.service.component.RecruitmentNotificationRequesterReader;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecruitmentNotificationService {
+
+    private final RecruitmentNotificationRequesterReader recruitmentNotificationRequesterReader;
+    private final RecruitmentNotificationRequesterRepository recruitmentNotificationRequesterRepository;
+
+    @Transactional
+    public void requestRecruitmentNotification(String recruitEmail, boolean isPolicyChecked) {
+        if (!isPolicyChecked) {
+            throw new AppException(ErrorCode.SHOULD_AGREE_POLICY);
+        }
+        if (recruitmentNotificationRequesterReader.existsByEmailAndSendStatus(recruitEmail, SendStatus.NOT_SENT)) {
+            throw new AppException(ErrorCode.ALREADY_REQUEST_NOTIFICATION);
+        }
+
+        recruitmentNotificationRequesterRepository.save(
+                RecruitmentNotificationRequester.of(recruitEmail, isPolicyChecked)
+        );
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/recruitment/service/component/RecruitmentNotificationRequesterReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/recruitment/service/component/RecruitmentNotificationRequesterReader.java
@@ -1,0 +1,19 @@
+package org.cotato.csquiz.domain.recruitment.service.component;
+
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.domain.recruitment.enums.SendStatus;
+import org.cotato.csquiz.domain.recruitment.repository.RecruitmentNotificationRequesterRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecruitmentNotificationRequesterReader {
+
+    private final RecruitmentNotificationRequesterRepository recruitmentNotificationRequesterRepository;
+
+    public boolean existsByEmailAndSendStatus(String email, SendStatus sendStatus) {
+        return recruitmentNotificationRequesterRepository.existsByEmailAndSendStatus(email, sendStatus);
+    }
+}

--- a/src/test/java/org/cotato/csquiz/domain/recruitment/service/RecruitmentNotificationServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/recruitment/service/RecruitmentNotificationServiceTest.java
@@ -1,0 +1,86 @@
+package org.cotato.csquiz.domain.recruitment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
+import org.cotato.csquiz.domain.recruitment.entity.RecruitmentNotificationRequester;
+import org.cotato.csquiz.domain.recruitment.enums.SendStatus;
+import org.cotato.csquiz.domain.recruitment.repository.RecruitmentNotificationRequesterRepository;
+import org.cotato.csquiz.domain.recruitment.service.component.RecruitmentNotificationRequesterReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class RecruitmentNotificationServiceTest {
+
+    @InjectMocks
+    private RecruitmentNotificationService recruitmentNotificationService;
+
+    @Mock
+    private RecruitmentNotificationRequesterReader recruitmentNotificationRequesterReader;
+
+    @Mock
+    private RecruitmentNotificationRequesterRepository recruitmentNotificationRequesterRepository;
+
+    private final String EMAIL = "user@example.com";
+
+    @Test
+    void policyChecked가_false이면_예외발생() {
+        // given
+        boolean isPolicyChecked = false;
+
+        // when & then
+        AppException ex = assertThrows(AppException.class,
+                () -> recruitmentNotificationService.requestRecruitmentNotification(EMAIL, isPolicyChecked));
+        assertEquals(ErrorCode.SHOULD_AGREE_POLICY, ex.getErrorCode());
+
+        verifyNoInteractions(recruitmentNotificationRequesterRepository);
+    }
+
+    @Test
+    void 이미_같은_이메일이_신청되면_예외발생() {
+        // given
+        boolean isPolicyChecked = true;
+        when(recruitmentNotificationRequesterReader
+                .existsByEmailAndSendStatus(EMAIL, SendStatus.NOT_SENT))
+                .thenReturn(true);
+
+        // when & then
+        AppException ex = assertThrows(AppException.class,
+                () -> recruitmentNotificationService.requestRecruitmentNotification(EMAIL, isPolicyChecked));
+        assertEquals(ErrorCode.ALREADY_REQUEST_NOTIFICATION, ex.getErrorCode());
+
+        verify(recruitmentNotificationRequesterReader).existsByEmailAndSendStatus(EMAIL, SendStatus.NOT_SENT);
+        verifyNoInteractions(recruitmentNotificationRequesterRepository);
+    }
+
+    @Test
+    void 모집_알림_신청시_저장() {
+        // given
+        boolean isPolicyChecked = true;
+        when(recruitmentNotificationRequesterReader
+                .existsByEmailAndSendStatus(EMAIL, SendStatus.NOT_SENT))
+                .thenReturn(false);
+
+        // when
+        recruitmentNotificationService.requestRecruitmentNotification(EMAIL, isPolicyChecked);
+
+        // then
+        verify(recruitmentNotificationRequesterReader).existsByEmailAndSendStatus(EMAIL, SendStatus.NOT_SENT);
+        verify(recruitmentNotificationRequesterRepository).save(
+                argThat((RecruitmentNotificationRequester r) ->
+                        EMAIL.equals(r.getEmail())
+                                && r.getSendStatus() == SendStatus.NOT_SENT
+                )
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
해당 PR은 [COT-342](https://github.com/IT-Cotato/COTATO-BE/pull/342) 커밋이 포함되어 있음
모집 알람 신청 시 저장하는 API

### Modification
구현


### Result
https://youthing.atlassian.net/browse/COT-263

### Test (option)
테스트 코드 참고


### SQL
Enum 컬럼 String 설정
```sql
ALTER TABLE recruitment_notification_requester
    MODIFY COLUMN send_status VARCHAR(255) NOT NULL;
```