### PR TITLE
[COT-270] Feature: 디스코드 랜덤 문제 전송 실패 방지 처리

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/config/JdaConfig.java
+++ b/src/main/java/org/cotato/csquiz/common/config/JdaConfig.java
@@ -3,7 +3,7 @@ package org.cotato.csquiz.common.config;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
-import org.cotato.csquiz.domain.education.service.DiscordButtonListener;
+import org.cotato.csquiz.domain.education.service.component.DiscordButtonListener;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/org/cotato/csquiz/domain/education/repository/QuizRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/repository/QuizRepository.java
@@ -1,11 +1,10 @@
 package org.cotato.csquiz.domain.education.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.cotato.csquiz.domain.education.entity.Education;
 import org.cotato.csquiz.domain.education.entity.Quiz;
 import org.cotato.csquiz.domain.education.enums.QuizStatus;
-import java.util.List;
-import java.util.Optional;
-import org.cotato.csquiz.domain.education.enums.QuizType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/org/cotato/csquiz/domain/education/repository/QuizRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/repository/QuizRepository.java
@@ -34,10 +34,10 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     @Query("""
             SELECT q
               FROM Quiz q
-             WHERE q.education   IN :eds
+             WHERE q.education   IN :educations
                AND TYPE(q)       = MultipleQuiz
-               AND LENGTH(q.question) <= :maxLen
+               AND LENGTH(q.question) <= :maxLength
             """)
-    List<Quiz> findMultipleQuizzesByEducationInAndQuestionLengthLE(@Param("eds") List<Education> educations,
-                                                                   @Param("maxLen") int maxLength);
+    List<Quiz> findMultipleQuizzesByEducationInAndQuestionLengthLE(@Param("educations") List<Education> educations,
+                                                                   @Param("maxLength") int maxLength);
 }

--- a/src/main/java/org/cotato/csquiz/domain/education/repository/QuizRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/repository/QuizRepository.java
@@ -5,6 +5,7 @@ import org.cotato.csquiz.domain.education.entity.Quiz;
 import org.cotato.csquiz.domain.education.enums.QuizStatus;
 import java.util.List;
 import java.util.Optional;
+import org.cotato.csquiz.domain.education.enums.QuizType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -30,4 +31,6 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     List<Quiz> findAllByEducationIdsInQuery(@Param("educationIds") List<Long> educationIds);
 
     Optional<Quiz> findFirstByEducationOrderByNumberDesc(Education education);
+
+    List<Quiz> findAllByEducationInAndQuizType(List<Education> educations, QuizType quizType);
 }

--- a/src/main/java/org/cotato/csquiz/domain/education/repository/QuizRepository.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/repository/QuizRepository.java
@@ -32,5 +32,13 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
 
     Optional<Quiz> findFirstByEducationOrderByNumberDesc(Education education);
 
-    List<Quiz> findAllByEducationInAndQuizType(List<Education> educations, QuizType quizType);
+    @Query("""
+            SELECT q
+              FROM Quiz q
+             WHERE q.education   IN :eds
+               AND TYPE(q)       = MultipleQuiz
+               AND LENGTH(q.question) <= :maxLen
+            """)
+    List<Quiz> findMultipleQuizzesByEducationInAndQuestionLengthLE(@Param("eds") List<Education> educations,
+                                                                   @Param("maxLen") int maxLength);
 }

--- a/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
@@ -1,5 +1,6 @@
 package org.cotato.csquiz.domain.education.scheduler;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.domain.education.entity.Quiz;
@@ -24,7 +25,7 @@ public class QuizScheduler {
     @Transactional(readOnly = true)
     @Scheduled(cron = "0 0 14 * * ?")
     public void sendRandomQuiz() {
-        Quiz quiz = quizReader.getRandomDiscordQuiz();
+        Quiz quiz = quizReader.getRandomDiscordQuiz().orElseThrow(() -> new EntityNotFoundException("디스코드에 전송할 랜덤 퀴즈를 찾을 수 없습니다."));
         RandomQuizResponse randomQuiz = RandomQuizResponse.from(quiz);
 
         discordService.sendMessageToTextChannel(DiscordUtil.getMultipleQuizEmbeds(randomQuiz),

--- a/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.domain.education.entity.Quiz;
 import org.cotato.csquiz.domain.education.service.ChoiceService;
-import org.cotato.csquiz.domain.education.service.DiscordService;
+import org.cotato.csquiz.domain.education.service.component.DiscordConnector;
 import org.cotato.csquiz.domain.education.service.component.QuizReader;
 import org.cotato.csquiz.domain.education.service.dto.RandomQuizResponse;
 import org.cotato.csquiz.domain.education.util.DiscordUtil;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class QuizScheduler {
 
-    private final DiscordService discordService;
+    private final DiscordConnector discordConnector;
     private final QuizReader quizReader;
     private final ChoiceService choiceService;
 
@@ -27,7 +27,7 @@ public class QuizScheduler {
         Quiz quiz = quizReader.getRandomDiscordQuiz();
         RandomQuizResponse randomQuiz = RandomQuizResponse.from(quiz);
 
-        discordService.sendMessageToTextChannel(DiscordUtil.getMultipleQuizEmbeds(randomQuiz),
+        discordConnector.sendMessageToTextChannel(DiscordUtil.getMultipleQuizEmbeds(randomQuiz),
                 DiscordUtil.getButtons(choiceService.findAllChoices(randomQuiz.id())));
         log.info("[디스코드 채널 문제 전송 완료: {}]", randomQuiz.id());
     }

--- a/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
@@ -25,7 +25,7 @@ public class QuizScheduler {
     @Transactional(readOnly = true)
     @Scheduled(cron = "0 0 14 * * ?")
     public void sendRandomQuiz() {
-        Quiz quiz = quizReader.getRandomDiscordQuiz().orElseThrow(() -> new EntityNotFoundException("디스코드에 전송할 랜덤 퀴즈를 찾을 수 없습니다."));
+        Quiz quiz = quizReader.getRandomDiscordQuiz();
         RandomQuizResponse randomQuiz = RandomQuizResponse.from(quiz);
 
         discordService.sendMessageToTextChannel(DiscordUtil.getMultipleQuizEmbeds(randomQuiz),

--- a/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
@@ -1,6 +1,5 @@
 package org.cotato.csquiz.domain.education.scheduler;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cotato.csquiz.domain.education.entity.Quiz;

--- a/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/scheduler/QuizScheduler.java
@@ -2,9 +2,10 @@ package org.cotato.csquiz.domain.education.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cotato.csquiz.domain.education.entity.Quiz;
 import org.cotato.csquiz.domain.education.service.ChoiceService;
 import org.cotato.csquiz.domain.education.service.DiscordService;
-import org.cotato.csquiz.domain.education.service.QuizService;
+import org.cotato.csquiz.domain.education.service.component.QuizReader;
 import org.cotato.csquiz.domain.education.service.dto.RandomQuizResponse;
 import org.cotato.csquiz.domain.education.util.DiscordUtil;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -17,13 +18,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuizScheduler {
 
     private final DiscordService discordService;
-    private final QuizService quizService;
+    private final QuizReader quizReader;
     private final ChoiceService choiceService;
 
     @Transactional(readOnly = true)
     @Scheduled(cron = "0 0 14 * * ?")
     public void sendRandomQuiz() {
-        RandomQuizResponse randomQuiz = quizService.pickRandomQuiz();
+        Quiz quiz = quizReader.getRandomDiscordQuiz();
+        RandomQuizResponse randomQuiz = RandomQuizResponse.from(quiz);
+
         discordService.sendMessageToTextChannel(DiscordUtil.getMultipleQuizEmbeds(randomQuiz),
                 DiscordUtil.getButtons(choiceService.findAllChoices(randomQuiz.id())));
         log.info("[디스코드 채널 문제 전송 완료: {}]", randomQuiz.id());

--- a/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/QuizService.java
@@ -34,7 +34,6 @@ import org.cotato.csquiz.common.error.exception.ImageException;
 import org.cotato.csquiz.common.s3.S3Uploader;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.service.MemberService;
-import org.cotato.csquiz.domain.education.cache.DiscordQuizRedisRepository;
 import org.cotato.csquiz.domain.education.cache.QuizAnswerRedisRepository;
 import org.cotato.csquiz.domain.education.entity.Choice;
 import org.cotato.csquiz.domain.education.entity.Education;
@@ -45,13 +44,11 @@ import org.cotato.csquiz.domain.education.entity.ShortAnswer;
 import org.cotato.csquiz.domain.education.entity.ShortQuiz;
 import org.cotato.csquiz.domain.education.enums.ChoiceCorrect;
 import org.cotato.csquiz.domain.education.enums.EducationStatus;
-import org.cotato.csquiz.domain.education.enums.QuizType;
 import org.cotato.csquiz.domain.education.repository.ChoiceRepository;
 import org.cotato.csquiz.domain.education.repository.EducationRepository;
 import org.cotato.csquiz.domain.education.repository.QuizRepository;
 import org.cotato.csquiz.domain.education.repository.ScorerRepository;
 import org.cotato.csquiz.domain.education.repository.ShortAnswerRepository;
-import org.cotato.csquiz.domain.education.service.dto.RandomQuizResponse;
 import org.cotato.csquiz.domain.education.util.AnswerUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,7 +68,6 @@ public class QuizService {
     private final ChoiceRepository choiceRepository;
     private final QuizAnswerRedisRepository quizAnswerRedisRepository;
     private final S3Uploader s3Uploader;
-    private final DiscordQuizRedisRepository discordQuizRedisRepository;
 
     @Transactional
     public void createQuizzes(Long educationId, CreateQuizzesRequest request) throws ImageException {
@@ -353,24 +349,5 @@ public class QuizService {
     private int generateRandomTime() {
         final ThreadLocalRandom random = ThreadLocalRandom.current();
         return random.nextInt(QuizService.RANDOM_DELAY_TIME_BOUNDARY);
-    }
-
-    @Transactional(readOnly = true)
-    public RandomQuizResponse pickRandomQuiz() {
-        List<Long> finishedEducationIds = educationRepository.findAllByStatus(EducationStatus.FINISHED).stream()
-                .map(Education::getId)
-                .toList();
-
-        List<Quiz> multipleQuizzes = quizRepository.findAllByEducationIdsInQuery(finishedEducationIds).stream()
-                .filter(quiz -> quiz.getQuizType() == QuizType.MULTIPLE_QUIZ)
-                .filter(quiz -> !discordQuizRedisRepository.isUsedInOneWeek(quiz.getId()))
-                .toList();
-
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        Quiz randomQuiz = multipleQuizzes.get(random.nextInt(multipleQuizzes.size()));
-
-        discordQuizRedisRepository.save(randomQuiz.getId());
-
-        return RandomQuizResponse.from(randomQuiz);
     }
 }

--- a/src/main/java/org/cotato/csquiz/domain/education/service/component/DiscordButtonListener.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/component/DiscordButtonListener.java
@@ -1,4 +1,4 @@
-package org.cotato.csquiz.domain.education.service;
+package org.cotato.csquiz.domain.education.service.component;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;

--- a/src/main/java/org/cotato/csquiz/domain/education/service/component/DiscordConnector.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/component/DiscordConnector.java
@@ -1,4 +1,4 @@
-package org.cotato.csquiz.domain.education.service;
+package org.cotato.csquiz.domain.education.service.component;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,12 +12,12 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
-public class DiscordService {
+public class DiscordConnector {
 
     private final JDA jda;
 

--- a/src/main/java/org/cotato/csquiz/domain/education/service/component/EducationReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/component/EducationReader.java
@@ -1,0 +1,24 @@
+package org.cotato.csquiz.domain.education.service.component;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.domain.education.entity.Education;
+import org.cotato.csquiz.domain.education.enums.EducationStatus;
+import org.cotato.csquiz.domain.education.repository.EducationRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EducationReader {
+
+    private final EducationRepository educationRepository;
+
+    public Education getById(final Long id) {
+        return educationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 교육이 존재하지 않습니다."));
+    }
+
+    public List<Education> getAllByStatus(EducationStatus educationStatus) {
+        return educationRepository.findAllByStatus(educationStatus);
+    }
+}

--- a/src/main/java/org/cotato/csquiz/domain/education/service/component/QuizReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/component/QuizReader.java
@@ -28,7 +28,6 @@ public class QuizReader {
 
         List<Quiz> multipleQuizzes = quizRepository.findMultipleQuizzesByEducationInAndQuestionLengthLE(finishedEducations, MAX_DISCORD_QUIZ_LENGTH).stream()
                 .filter(quiz -> !discordQuizRedisRepository.isUsedInOneWeek(quiz.getId()))
-                .filter(quiz -> quiz.getQuestion().length() <= MAX_DISCORD_QUIZ_LENGTH)
                 .toList();
 
         if (multipleQuizzes.isEmpty()) {

--- a/src/main/java/org/cotato/csquiz/domain/education/service/component/QuizReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/education/service/component/QuizReader.java
@@ -1,0 +1,40 @@
+package org.cotato.csquiz.domain.education.service.component;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.domain.education.cache.DiscordQuizRedisRepository;
+import org.cotato.csquiz.domain.education.entity.Education;
+import org.cotato.csquiz.domain.education.entity.Quiz;
+import org.cotato.csquiz.domain.education.enums.EducationStatus;
+import org.cotato.csquiz.domain.education.enums.QuizType;
+import org.cotato.csquiz.domain.education.repository.QuizRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class QuizReader {
+
+    private static final int MAX_DISCORD_QUIZ_LENGTH = 80;
+
+    private final EducationReader educationReader;
+    private final QuizRepository quizRepository;
+    private final DiscordQuizRedisRepository discordQuizRedisRepository;
+
+    @Transactional(readOnly = true)
+    public Quiz getRandomDiscordQuiz() {
+        List<Education> finishedEducations = educationReader.getAllByStatus(EducationStatus.FINISHED);
+
+        List<Quiz> multipleQuizzes = quizRepository.findAllByEducationInAndQuizType(finishedEducations, QuizType.MULTIPLE_QUIZ).stream()
+                .filter(quiz -> !discordQuizRedisRepository.isUsedInOneWeek(quiz.getId()))
+                .filter(quiz -> quiz.getQuestion().length() <= MAX_DISCORD_QUIZ_LENGTH)
+                .toList();
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        Quiz quiz = multipleQuizzes.get(random.nextInt(multipleQuizzes.size()));
+        discordQuizRedisRepository.save(quiz.getId());
+
+        return quiz;
+    }
+}

--- a/src/test/java/org/cotato/csquiz/domain/education/service/component/QuizReaderTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/education/service/component/QuizReaderTest.java
@@ -1,0 +1,88 @@
+package org.cotato.csquiz.domain.education.service.component;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.cotato.csquiz.domain.education.cache.DiscordQuizRedisRepository;
+import org.cotato.csquiz.domain.education.entity.Education;
+import org.cotato.csquiz.domain.education.entity.Quiz;
+import org.cotato.csquiz.domain.education.enums.EducationStatus;
+import org.cotato.csquiz.domain.education.repository.QuizRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class QuizReaderTest {
+
+    @Mock
+    private EducationReader educationReader;
+
+    @Mock
+    private QuizRepository quizRepository;
+
+    @Mock
+    private DiscordQuizRedisRepository discordQuizRedisRepository;
+
+    @InjectMocks
+    private QuizReader quizReader;
+
+    @Test
+    void getRandomDiscordQuiz_singleQuizAvailable_returnsThatQuiz() {
+        // given
+        Education edu = mock(Education.class);
+        List<Education> eds = List.of(edu);
+        when(educationReader.getAllByStatus(EducationStatus.FINISHED))
+                .thenReturn(eds);
+
+        Quiz quiz = new Quiz(1, "short question", null, edu, 5);
+        ReflectionTestUtils.setField(quiz, "id", 1L);
+
+        when(quizRepository.findMultipleQuizzesByEducationInAndQuestionLengthLE(eds, 80))
+                .thenReturn(List.of(quiz));
+        when(discordQuizRedisRepository.isUsedInOneWeek(1L))
+                .thenReturn(false);
+
+        // when
+        Optional<Quiz> result = quizReader.getRandomDiscordQuiz();
+
+        // then
+        assertTrue(result.isPresent(), "퀴즈가 반환되어야 한다");
+        assertSame(quiz, result.get(), "반환된 퀴즈가 기대한 객체여야 한다");
+        verify(discordQuizRedisRepository).save(1L);
+    }
+
+    @Test
+    void getRandomDiscordQuiz_allQuizzesUsed_throwsExceptionAndDoesNotSave() {
+        // given
+        Education edu = mock(Education.class);
+        List<Education> eds = List.of(edu);
+        when(educationReader.getAllByStatus(EducationStatus.FINISHED))
+                .thenReturn(eds);
+
+        Quiz quiz = new Quiz(1, "another question", null, edu, 5);
+        ReflectionTestUtils.setField(quiz, "id", 2L);
+
+        when(quizRepository.findMultipleQuizzesByEducationInAndQuestionLengthLE(eds, 80))
+                .thenReturn(List.of(quiz));
+        when(discordQuizRedisRepository.isUsedInOneWeek(2L))
+                .thenReturn(true);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class,
+                () -> quizReader.getRandomDiscordQuiz(),
+                "사용된 퀴즈만 남을 경우 nextInt(0) 에러가 발생해야 한다");
+        verify(discordQuizRedisRepository, never()).save(anyLong());
+    }
+}

--- a/src/test/java/org/cotato/csquiz/domain/education/service/component/QuizReaderTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/education/service/component/QuizReaderTest.java
@@ -74,8 +74,8 @@ class QuizReaderTest {
                 .thenReturn(true);
 
         // when & then
-        IllegalArgumentException ex = assertThrows(
-                IllegalArgumentException.class,
+        EntityNotFoundException ex = assertThrows(
+                EntityNotFoundException.class,
                 () -> quizReader.getRandomDiscordQuiz()
         );
         assertEquals("디스코드에 전송할 랜덤 퀴즈가 없습니다.", ex.getMessage(), "사용 가능한 퀴즈가 없을 때 지정한 메시지의 예외가 발생해야 한다");


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

현재 디스코드에 2시마다 퀴즈가 전송되는 상황에서 퀴즈 문제의 길이가 80을 넘어가면 에러로 인해 아무 문제도 전송되지 않는다.
이는 JDA 설정에 따른 문제이다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

길이가 80이하인 문제만 조회 후 전송한다.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-270&sprints=9

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->