### PR TITLE
[COT-271] Feature: JWT에서 role 필드를 제거

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/cotato/csquiz/common/config/filter/JwtAuthenticationFilter.java
@@ -51,12 +51,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                                             Authentication authResult) {
 
         PrincipalDetails principal = (PrincipalDetails) authResult.getPrincipal();
-        String grantedAuthority = authResult.getAuthorities().stream()
-                .findAny()
-                .orElseThrow()
-                .toString();
 
-        Token token = jwtTokenProvider.createToken(principal.getMember().getId(), grantedAuthority);
+        Token token = jwtTokenProvider.createToken(principal.getMember());
 
         String accessToken = token.getAccessToken();
         response.addHeader("accessToken", accessToken);

--- a/src/main/java/org/cotato/csquiz/common/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/cotato/csquiz/common/config/jwt/JwtTokenProvider.java
@@ -5,14 +5,13 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
-import org.cotato.csquiz.domain.auth.constant.TokenConstants;
 import org.cotato.csquiz.common.error.exception.FilterAuthenticationException;
 import org.cotato.csquiz.common.error.exception.InterceptorException;
+import org.cotato.csquiz.domain.auth.constant.TokenConstants;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -68,7 +67,6 @@ public class JwtTokenProvider {
                 .build();
     }
 
-    @Transactional
     public void setBlackList(String token) {
         BlackList blackList = BlackList.builder()
                 .id(token)

--- a/src/main/java/org/cotato/csquiz/common/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/cotato/csquiz/common/config/jwt/JwtTokenProvider.java
@@ -60,10 +60,10 @@ public class JwtTokenProvider {
         return claims.get("type", String.class);
     }
 
-    public Token createToken(Long id, String authority) {
+    public Token createToken(final Member member) {
         return Token.builder()
-                .accessToken(createAccessToken(id, authority))
-                .refreshToken(createRefreshToken(id, authority))
+                .accessToken(createAccessToken(member.getId()))
+                .refreshToken(createRefreshToken(member.getId()))
                 .build();
     }
 
@@ -80,10 +80,9 @@ public class JwtTokenProvider {
         return claims.getExpiration().getTime() - new Date().getTime();
     }
 
-    private String createAccessToken(Long id, String authority) {
+    private String createAccessToken(final Long id) {
         Claims claims = Jwts.claims();
         claims.put("id", id);
-        claims.put("role", authority);
         claims.put("type", TokenConstants.ACCESS_TOKEN);
         return Jwts.builder()
                 .setClaims(claims)
@@ -93,10 +92,9 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    private String createRefreshToken(Long id, String authority) {
+    private String createRefreshToken(final Long id) {
         Claims claims = Jwts.claims();
         claims.put("id", id);
-        claims.put("role", authority);
         claims.put("type", TokenConstants.REFRESH_TOKEN);
         return Jwts.builder()
                 .setClaims(claims)

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
@@ -84,7 +84,7 @@ public class AuthService {
         Member member = memberReader.findById(memberId);
 
         RefreshToken findToken = refreshTokenRepository.findById(memberId)
-                .orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_FOUND));
+                .orElseThrow(() -> new AppException(ErrorCode.REFRESH_TOKEN_NOT_EXIST));
         log.info("[브라우저에서 들어온 쿠키] == [DB에 저장된 토큰], {}", refreshToken.equals(findToken.getRefreshToken()));
 
         if (!refreshToken.equals(findToken.getRefreshToken())) {

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
@@ -27,6 +27,7 @@ import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.EmailType;
 import org.cotato.csquiz.domain.auth.repository.MemberRepository;
 import org.cotato.csquiz.domain.auth.service.component.EmailCodeManager;
+import org.cotato.csquiz.domain.auth.service.component.MemberReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -43,6 +44,7 @@ public class AuthService {
     private static final String REFRESH_TOKEN = "refreshToken";
 
     private final PolicyService policyService;
+    private final MemberReader memberReader;
     private final MemberRepository memberRepository;
     private final ValidateService validateService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
@@ -79,7 +81,7 @@ public class AuthService {
             throw new AppException(ErrorCode.REISSUE_FAIL);
         }
         Long memberId = jwtTokenProvider.getMemberId(refreshToken);
-        String role = jwtTokenProvider.getRole(refreshToken);
+        Member member = memberReader.findById(memberId);
 
         RefreshToken findToken = refreshTokenRepository.findById(memberId)
                 .orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_FOUND));
@@ -90,7 +92,7 @@ public class AuthService {
             throw new AppException(ErrorCode.REFRESH_TOKEN_NOT_EXIST);
         }
         jwtTokenProvider.setBlackList(refreshToken);
-        Token token = jwtTokenProvider.createToken(memberId, role);
+        Token token = jwtTokenProvider.createToken(member);
         findToken.updateRefreshToken(token.getRefreshToken());
         refreshTokenRepository.save(findToken);
 
@@ -147,11 +149,9 @@ public class AuthService {
 
     public FindPasswordResponse verifyPasswordCode(String email, String code) {
         emailCodeManager.verifyCode(EmailType.UPDATE_PASSWORD, email, code);
-        Member findMember = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_FOUND));
-        String role = findMember.getRole().getKey();
+        Member member = memberReader.getByEmail(email);
 
-        Token token = jwtTokenProvider.createToken(findMember.getId(), role);
+        Token token = jwtTokenProvider.createToken(member);
         return FindPasswordResponse.from(token.getAccessToken());
     }
 

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/component/MemberReader.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/component/MemberReader.java
@@ -3,6 +3,8 @@ package org.cotato.csquiz.domain.auth.service.component;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.repository.MemberRepository;
 import org.cotato.csquiz.domain.generation.entity.Generation;
@@ -36,5 +38,10 @@ public class MemberReader {
             throw new EntityNotFoundException("일부 부원이 존재하지 않습니다");
         }
         return members;
+    }
+
+    public Member getByEmail(final String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AppException(ErrorCode.EMAIL_NOT_FOUND));
     }
 }

--- a/src/test/java/org/cotato/csquiz/common/config/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/cotato/csquiz/common/config/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,74 @@
+package org.cotato.csquiz.common.config.jwt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.cotato.csquiz.domain.auth.constant.TokenConstants;
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+
+    private static final String SECRET = "testSecretKey";
+
+    private static final long ACCESS_EXPIRATION = 1_000_000L;
+
+    private static final long REFRESH_EXPIRATION = 2_000_000L;
+
+    @InjectMocks
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private BlackListRepository blackListRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(jwtTokenProvider, "secretKey", SECRET);
+        ReflectionTestUtils.setField(jwtTokenProvider, "accessExpiration", ACCESS_EXPIRATION);
+        ReflectionTestUtils.setField(jwtTokenProvider, "refreshExpiration", REFRESH_EXPIRATION);
+    }
+
+    @Test
+    @DisplayName("JWT 토큰 생성 검증")
+    void createToken_ShouldGenerateValidAccessAndRefreshTokens() {
+        // given
+        Member member = Member.defaultMember("email", "pwd","name", "010");
+        ReflectionTestUtils.setField(member, "id", 42L);
+
+        // when
+        Token token = jwtTokenProvider.createToken(member);
+
+        // then
+        Claims accessClaims = Jwts.parser()
+                .setSigningKey(SECRET)
+                .parseClaimsJws(token.getAccessToken())
+                .getBody();
+        assertEquals(42L, accessClaims.get("id", Long.class));
+        assertEquals(TokenConstants.ACCESS_TOKEN, accessClaims.get("type", String.class));
+        long accessDuration = accessClaims.getExpiration().getTime() - accessClaims.getIssuedAt().getTime();
+        assertEquals(ACCESS_EXPIRATION, accessDuration);
+
+        Claims refreshClaims = Jwts.parser()
+                .setSigningKey(SECRET)
+                .parseClaimsJws(token.getRefreshToken())
+                .getBody();
+        assertEquals(42L, refreshClaims.get("id", Long.class));
+        assertEquals(TokenConstants.REFRESH_TOKEN, refreshClaims.get("type", String.class));
+        long refreshDuration = refreshClaims.getExpiration().getTime() - refreshClaims.getIssuedAt().getTime();
+        assertEquals(REFRESH_EXPIRATION, refreshDuration);
+    }
+}


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

Spring Security에서 authority 기반으로 API 권한 체크를 하지 않기에 더이상 토큰에 role을 담을 필요가 없음
또한 추후에 필요가 있더라도, id기준으로 조회 후 `member.getRole()`기준으로 추가하면 되기에 토큰 자체에 role 이 필요가 없음.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

제거한다.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-271&sprints=9

### Test (option)
<!-- 테스트 결과를 보여주세요. -->

- admin 권한 api 테스트 진행 완료


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->