### PR TITLE
[COT-280] Refactor: 기수별 활동 부원 API 경로 수정

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/member/controller/GenerationMemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/GenerationMemberController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,10 +43,10 @@ public class GenerationMemberController {
     }
 
     @RoleAuthority(MemberRole.ADMIN)
-    @PatchMapping
-    public ResponseEntity<Void> updateGenerationMemberRole(
+    @PatchMapping("/{generationMemberId}/role")
+    public ResponseEntity<Void> updateGenerationMemberRole(@PathVariable("generationMemberId") Long generationMemberId,
             @RequestBody @Valid UpdateGenerationMemberRoleRequest request) {
-        generationMemberService.updateGenerationMemberRole(request.generationMemberId(), request.role());
+        generationMemberService.updateGenerationMemberRole(generationMemberId, request.role());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/cotato/csquiz/api/member/controller/GenerationMemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/GenerationMemberController.java
@@ -1,5 +1,6 @@
 package org.cotato.csquiz.api.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class GenerationMemberController {
 
     private final GenerationMemberService generationMemberService;
 
+    @Operation(summary = "기수별 활동 멤버 조회")
     @RoleAuthority(MemberRole.ADMIN)
     @GetMapping
     public ResponseEntity<GenerationMemberInfoResponse> findGenerationMember(
@@ -35,6 +37,7 @@ public class GenerationMemberController {
         return ResponseEntity.ok().body(generationMemberService.findGenerationMemberByGeneration(generationId));
     }
 
+    @Operation(summary = "기수별 활동 멤버 추가")
     @RoleAuthority(MemberRole.ADMIN)
     @PostMapping
     public ResponseEntity<Void> addGenerationMember(@RequestBody @Valid CreateGenerationMemberRequest request) {
@@ -42,6 +45,7 @@ public class GenerationMemberController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "기수별 활동 멤버 역할 수정")
     @RoleAuthority(MemberRole.ADMIN)
     @PatchMapping("/{generationMemberId}/role")
     public ResponseEntity<Void> updateGenerationMemberRole(@PathVariable("generationMemberId") Long generationMemberId,
@@ -50,6 +54,7 @@ public class GenerationMemberController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "기수별 활동 멤버 삭제")
     @RoleAuthority(MemberRole.ADMIN)
     @DeleteMapping
     public ResponseEntity<Void> deleteGenerationMember(@RequestParam(name = "generationMemberId") Long generationMemberId) {

--- a/src/main/java/org/cotato/csquiz/api/member/dto/UpdateGenerationMemberRoleRequest.java
+++ b/src/main/java/org/cotato/csquiz/api/member/dto/UpdateGenerationMemberRoleRequest.java
@@ -4,8 +4,6 @@ import jakarta.validation.constraints.NotNull;
 import org.cotato.csquiz.domain.generation.enums.GenerationMemberRole;
 
 public record UpdateGenerationMemberRoleRequest(
-        @NotNull(message = "멤버별 활동 정보를 입력해주세요")
-        Long generationMemberId,
         @NotNull(message = "역할을 입력해주세요")
         GenerationMemberRole role
 ) {

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/GenerationMemberService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/GenerationMemberService.java
@@ -53,7 +53,7 @@ public class GenerationMemberService {
     }
 
     @Transactional
-    public void updateGenerationMemberRole(Long generationMemberId, GenerationMemberRole memberRole) {
+    public void updateGenerationMemberRole(final Long generationMemberId, final GenerationMemberRole memberRole) {
         GenerationMember generationMember = generationMemberReader.findById(generationMemberId);
         generationMember.updateMemberRole(memberRole);
     }

--- a/src/test/java/org/cotato/csquiz/domain/auth/service/GenerationMemberServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/auth/service/GenerationMemberServiceTest.java
@@ -2,6 +2,7 @@ package org.cotato.csquiz.domain.auth.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.cotato.csquiz.domain.auth.service.component.GenerationMemberReader;
@@ -41,5 +42,6 @@ class GenerationMemberServiceTest {
 
         // then
         assertEquals(GenerationMemberRole.LEADER_TEAM, generationMemberReader.findById(generationMemberId).getRole());
+        verify(generationMember).updateMemberRole(targetRole);
     }
 }

--- a/src/test/java/org/cotato/csquiz/domain/auth/service/GenerationMemberServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/auth/service/GenerationMemberServiceTest.java
@@ -1,0 +1,45 @@
+package org.cotato.csquiz.domain.auth.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.cotato.csquiz.domain.auth.service.component.GenerationMemberReader;
+import org.cotato.csquiz.domain.generation.entity.GenerationMember;
+import org.cotato.csquiz.domain.generation.enums.GenerationMemberRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GenerationMemberServiceTest {
+
+    @InjectMocks
+    private GenerationMemberService generationMemberService;
+
+    @Mock
+    private GenerationMemberReader generationMemberReader;
+
+    @Test
+    @DisplayName("기수별 활동 부원 역할 수정 테스트")
+    void updateGenerationMemberRoleTest() {
+        // given
+        Long generationMemberId = 1L;
+        GenerationMemberRole targetRole = GenerationMemberRole.LEADER_TEAM;
+
+        GenerationMember generationMember = mock(GenerationMember.class);
+        ReflectionTestUtils.setField(generationMember, "id", generationMemberId);
+        when(generationMemberReader.findById(generationMemberId)).thenReturn(generationMember);
+        when(generationMember.getRole()).thenReturn(GenerationMemberRole.LEADER_TEAM);
+
+        // when
+        generationMemberService.updateGenerationMemberRole(generationMemberId, targetRole);
+
+        // then
+        assertEquals(GenerationMemberRole.LEADER_TEAM, generationMemberReader.findById(generationMemberId).getRole());
+    }
+}


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

기수별 활동 부원 API 경로가 restful하지 않다.
부원 역할 수정
기존 : PATCH /v2/api/generation-members

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

아래와 같이 수정한다.
PATCH /v2/api/generation-members/{generationMemberId}/role

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/jira/software/projects/COT/boards/2?selectedIssue=COT-280&sprints=9

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->