### PR TITLE
[COT-279] Feature: PageResponse로 페이징 시 필요한 필드만 반환한다.

### DIFF
--- a/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
+++ b/src/main/java/org/cotato/csquiz/api/member/controller/MemberController.java
@@ -19,6 +19,7 @@ import org.cotato.csquiz.api.member.dto.SearchedMembersResponse;
 import org.cotato.csquiz.api.member.dto.UpdatePasswordRequest;
 import org.cotato.csquiz.api.member.dto.UpdatePhoneNumberRequest;
 import org.cotato.csquiz.api.member.dto.UpdateProfileInfoRequest;
+import org.cotato.csquiz.common.response.PageResponse;
 import org.cotato.csquiz.common.role.RoleAuthority;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.MemberPosition;
@@ -75,12 +76,12 @@ public class MemberController {
     @Operation(summary = "OM 검색 API")
     @RoleAuthority(MemberRole.ADMIN)
     @GetMapping(value = "/search", params = "status=RETIRED")
-    public ResponseEntity<Page<MemberResponse>> findRetiredMembers(
+    public ResponseEntity<PageResponse<MemberResponse>> findRetiredMembers(
             @RequestParam(value = "passedGenerationNumber", required = false) Integer passedGenerationNumber,
             @RequestParam(value = "position", required = false) MemberPosition position,
             @RequestParam(value = "name", required = false) String name,
             Pageable pageable) {
-        return ResponseEntity.ok().body(memberService.getMembersByName(passedGenerationNumber, position, name, MemberStatus.RETIRED, pageable));
+        return ResponseEntity.ok().body(PageResponse.of(memberService.getMembersByName(passedGenerationNumber, position, name, MemberStatus.RETIRED, pageable)));
     }
 
     @PatchMapping("/update/password")
@@ -140,10 +141,10 @@ public class MemberController {
     @Operation(summary = "회원 상태에 따른 조회 요청 API")
     @RoleAuthority(MemberRole.ADMIN)
     @GetMapping(params = "status")
-    public ResponseEntity<Page<MemberResponse>> findMembersByStatus(
+    public ResponseEntity<PageResponse<MemberResponse>> findMembersByStatus(
             @RequestParam("status") MemberStatus status,
             @PageableDefault(sort = {"name"}, direction = Sort.Direction.ASC) Pageable pageable) {
-        return ResponseEntity.ok().body(memberService.getMembersByStatus(status, pageable));
+        return ResponseEntity.ok().body(PageResponse.of(memberService.getMembersByStatus(status, pageable)));
     }
 
     @Operation(summary = "부원 가입 승인")

--- a/src/main/java/org/cotato/csquiz/common/response/PageResponse.java
+++ b/src/main/java/org/cotato/csquiz/common/response/PageResponse.java
@@ -1,0 +1,28 @@
+package org.cotato.csquiz.common.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+        List<T> content,
+        Boolean hasNext,
+        int totalPages,
+        long totalElements,
+        int page,
+        int size,
+        Boolean isFirst,
+        Boolean isLast
+) {
+    public static <T> PageResponse<T> of(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.hasNext(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.getNumber(),
+                page.getSize(),
+                page.isFirst(),
+                page.isLast()
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

현재 페이징을 활용하는 API(OM 검색 및 회원 상태에 따른 조회)에는 필요 이상의 필드가 반환되고 있다.

예시
```json
{
  "totalPages": 0,
  "totalElements": 0,
  "size": 0,
  "content": [
    {
      "memberId": 0,
      "name": "string",
      "backFourNumber": "string",
      "role": "MEMBER",
      "position": "NONE",
      "status": "INACTIVE",
      "passedGenerationNumber": 0
    }
  ],
  "number": 0,
  "sort": {
    "empty": true,
    "sorted": true,
    "unsorted": true
  },
  "numberOfElements": 0,
  "pageable": {
    "offset": 0,
    "sort": {
      "empty": true,
      "sorted": true,
      "unsorted": true
    },
    "pageSize": 0,
    "pageNumber": 0,
    "unpaged": true,
    "paged": true
  },
  "first": true,
  "last": true,
  "empty": true
}
```

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

필요한 필드만 남긴다.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

https://youthing.atlassian.net/browse/COT-279

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->