### PR TITLE
[COT-274] Feature: 부원 가입 승인/거절 시 이메일 발송 이벤트 처리

### DIFF
--- a/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
+++ b/src/main/java/org/cotato/csquiz/common/error/ErrorCode.java
@@ -130,6 +130,7 @@ public enum ErrorCode {
     DISCORD_BUTTON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-012", "디스코드 버튼 이벤트 ID를 찾지 못했습니다."),
     EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-013", "이메일 전송에 실패했습니다."),
     FILE_GENERATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S-014", "엑셀 파일 생성에 실패했습니다."),
+    EVENT_TYPE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "S-015", "이벤트 처리 중 에러 발생"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/cotato/csquiz/common/event/CotatoEvent.java
+++ b/src/main/java/org/cotato/csquiz/common/event/CotatoEvent.java
@@ -1,0 +1,17 @@
+package org.cotato.csquiz.common.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CotatoEvent<T> {
+
+    private final EventType type;
+    private final T data;
+}

--- a/src/main/java/org/cotato/csquiz/common/event/CotatoEventListener.java
+++ b/src/main/java/org/cotato/csquiz/common/event/CotatoEventListener.java
@@ -1,6 +1,8 @@
 package org.cotato.csquiz.common.event;
 
 import lombok.RequiredArgsConstructor;
+ import org.cotato.csquiz.common.error.ErrorCode;
+import org.cotato.csquiz.common.error.exception.AppException;
 import org.cotato.csquiz.domain.auth.service.EmailNotificationService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -17,6 +19,7 @@ public class CotatoEventListener {
         switch (event.getType()) {
             case APPROVE_MEMBER -> emailNotificationService.sendSignUpApprovedToEmail(event.getData());
             case REJECT_MEMBER -> emailNotificationService.sendSignupRejectionToEmail(event.getData());
+            default -> throw new AppException(ErrorCode.EVENT_TYPE_EXCEPTION);
         }
     }
 }

--- a/src/main/java/org/cotato/csquiz/common/event/CotatoEventListener.java
+++ b/src/main/java/org/cotato/csquiz/common/event/CotatoEventListener.java
@@ -13,7 +13,7 @@ public class CotatoEventListener {
     private final EmailNotificationService emailNotificationService;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-    public void handleCotatoEvent(EmailSendEvent event) {
+    public void handleEmailSentEvent(EmailSendEvent event) {
         switch (event.getType()) {
             case APPROVE_MEMBER -> emailNotificationService.sendSignUpApprovedToEmail(event.getData());
             case REJECT_MEMBER -> emailNotificationService.sendSignupRejectionToEmail(event.getData());

--- a/src/main/java/org/cotato/csquiz/common/event/CotatoEventListener.java
+++ b/src/main/java/org/cotato/csquiz/common/event/CotatoEventListener.java
@@ -1,0 +1,22 @@
+package org.cotato.csquiz.common.event;
+
+import lombok.RequiredArgsConstructor;
+import org.cotato.csquiz.domain.auth.service.EmailNotificationService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class CotatoEventListener {
+
+    private final EmailNotificationService emailNotificationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleCotatoEvent(EmailSendEvent event) {
+        switch (event.getType()) {
+            case APPROVE_MEMBER -> emailNotificationService.sendSignUpApprovedToEmail(event.getData());
+            case REJECT_MEMBER -> emailNotificationService.sendSignupRejectionToEmail(event.getData());
+        }
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/event/CotatoEventPublisher.java
+++ b/src/main/java/org/cotato/csquiz/common/event/CotatoEventPublisher.java
@@ -1,0 +1,16 @@
+package org.cotato.csquiz.common.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CotatoEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public <T> void publishEvent(CotatoEvent<T> event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/event/EmailSendEvent.java
+++ b/src/main/java/org/cotato/csquiz/common/event/EmailSendEvent.java
@@ -1,0 +1,10 @@
+package org.cotato.csquiz.common.event;
+
+import org.cotato.csquiz.domain.auth.entity.Member;
+
+public class EmailSendEvent extends CotatoEvent<Member> {
+
+    public EmailSendEvent(EventType type, Member data) {
+        super(type, data);
+    }
+}

--- a/src/main/java/org/cotato/csquiz/common/event/EventType.java
+++ b/src/main/java/org/cotato/csquiz/common/event/EventType.java
@@ -1,0 +1,14 @@
+package org.cotato.csquiz.common.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+
+    APPROVE_MEMBER("부원 가입 승인"),
+    REJECT_MEMBER("부원 가입 거절");
+
+    private final String description;
+}

--- a/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
+++ b/src/main/java/org/cotato/csquiz/domain/auth/service/AuthService.java
@@ -144,7 +144,6 @@ public class AuthService {
         String verificationMessage = getVerificationMessageBody(verificationCode);
 
         emailSender.sendEmail(request.email(), verificationMessage, EmailConstants.SIGNUP_SUBJECT);
-
     }
 
     public FindPasswordResponse verifyPasswordCode(String email, String code) {

--- a/src/test/java/org/cotato/csquiz/common/event/CotatoEventListenerTest.java
+++ b/src/test/java/org/cotato/csquiz/common/event/CotatoEventListenerTest.java
@@ -1,0 +1,57 @@
+package org.cotato.csquiz.common.event;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.cotato.csquiz.domain.auth.entity.Member;
+import org.cotato.csquiz.domain.auth.service.EmailNotificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CotatoEventListenerTest {
+
+    @InjectMocks
+    private CotatoEventListener cotatoEventListener;
+
+    @Mock
+    private EmailNotificationService emailNotificationService;
+
+    @Test
+    @DisplayName("부원 가입 거절 시 이메일 발송 테스트")
+    void whenApproveMember_then_sendSignUpApprovedToEmail_호출() {
+        // given
+        Member member = mock(Member.class);
+        EmailSendEvent event = new EmailSendEvent(EventType.APPROVE_MEMBER, member);
+
+        // when
+        cotatoEventListener.handleEmailSentEvent(event);
+
+        // then
+        verify(emailNotificationService, times(1))
+                .sendSignUpApprovedToEmail(member);
+        verifyNoMoreInteractions(emailNotificationService);
+    }
+
+    @Test
+    void whenRejectMember_then_sendSignupRejectionToEmail_호출() {
+        // given
+        Member member = mock(Member.class);
+        EmailSendEvent event = new EmailSendEvent(EventType.REJECT_MEMBER, member);
+
+        // when
+        cotatoEventListener.handleEmailSentEvent(event);
+
+        // then
+        verify(emailNotificationService, times(1))
+                .sendSignupRejectionToEmail(member);
+        verifyNoMoreInteractions(emailNotificationService);
+    }
+
+}

--- a/src/test/java/org/cotato/csquiz/common/event/CotatoEventPublisherTest.java
+++ b/src/test/java/org/cotato/csquiz/common/event/CotatoEventPublisherTest.java
@@ -1,0 +1,39 @@
+package org.cotato.csquiz.common.event;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class CotatoEventPublisherTest {
+
+    @InjectMocks
+    private CotatoEventPublisher cotatoEventPublisher;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Test
+    @DisplayName("이벤트 발행 테스트")
+    void publishEvent() {
+        // given
+        CotatoEvent<String> event = CotatoEvent.<String>builder()
+                .type(EventType.APPROVE_MEMBER)
+                .data("test")
+                .build();
+
+        // when
+        cotatoEventPublisher.publishEvent(event);
+
+        // then
+        assertNotNull(event);
+        verify(applicationEventPublisher).publishEvent(event);
+    }
+}

--- a/src/test/java/org/cotato/csquiz/domain/auth/service/AdminMemberServiceTest.java
+++ b/src/test/java/org/cotato/csquiz/domain/auth/service/AdminMemberServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import org.cotato.csquiz.common.error.ErrorCode;
 import org.cotato.csquiz.common.error.exception.AppException;
+import org.cotato.csquiz.common.event.CotatoEventPublisher;
 import org.cotato.csquiz.domain.auth.entity.Member;
 import org.cotato.csquiz.domain.auth.enums.MemberPosition;
 import org.cotato.csquiz.domain.auth.enums.MemberRole;
@@ -39,7 +40,7 @@ class AdminMemberServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private EmailNotificationService emailNotificationService;
+    private CotatoEventPublisher cotatoEventPublisher;
 
     @Test
     void 부원_승인_요청() {


### PR DESCRIPTION
### Motivation
<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

현재 부원 가입 승인/거절 요청 시 외부 API를 호출하는 로직이 포함되어있다.
클래스가 분리되어있지만 Service 클래스 간의 결합도가 높아지는 상황
이는 하나의 메서드에 책임을 과도화 하게 된다.

### Modification
<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

이벤트를 발행해서 메서드의 책임을 낮춘다.

### Result
<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)
<!-- 테스트 결과를 보여주세요. -->


### SQL
<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->